### PR TITLE
🐛 fix: table UI row background

### DIFF
--- a/components/round/calculation/holesTable.tsx
+++ b/components/round/calculation/holesTable.tsx
@@ -50,7 +50,7 @@ const HolesTable = () => {
             );
           })}
           <TableRow key={"total"} className="bg-secondary dark:bg-ring">
-            <TableCell className="first:rounded-l-lg last:rounded-r-lg bg-secondary dark:bg-ring">
+            <TableCell className="first:rounded-l-lg !rounded-tl-none last:rounded-r-lg bg-secondary dark:bg-ring">
               Total
             </TableCell>
             <TableCell className="bg-secondary dark:bg-ring">
@@ -68,7 +68,7 @@ const HolesTable = () => {
                 return acc + hole.hcpStrokes;
               }, 0)}
             </TableCell>
-            <TableCell className="first:rounded-l-lg last:rounded-r-lg bg-secondary dark:bg-ring">
+            <TableCell className="first:rounded-l-lg last:rounded-r-lg !rounded-tr-none bg-secondary dark:bg-ring">
               {holes.reduce((acc, hole) => {
                 return acc + calculateHoleAdjustedScore(hole);
               }, 0)}


### PR DESCRIPTION
## What was done
- Fixed a UI issue where the row background for the total was rounded

## How to test
- Visit /dashboard and view a round calculation
- See that the total row for the holes table has background that fills the entire cell (corners)

## Future work
- None