### PR TITLE
📱 fix: round calculation stats labels responsivity

### DIFF
--- a/components/round/calculation/AGSCalculationDisplay.tsx
+++ b/components/round/calculation/AGSCalculationDisplay.tsx
@@ -17,7 +17,7 @@ const AGSCalculationDisplay = () => {
   return (
     <section className="space-y-4">
       <H3>Adjusted Gross Score</H3>
-      <div className="grid grid-cols-1 lg:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4 lg:flex items-end">
         <div>
           <Label className="mr-2">Adjusted Played Score:</Label>
           <Input

--- a/components/round/calculation/ScoreDiffCalculationDisplay.tsx
+++ b/components/round/calculation/ScoreDiffCalculationDisplay.tsx
@@ -18,7 +18,7 @@ const ScoreDiffCalculationDisplay = () => {
   return (
     <section className="space-y-4">
       <H3>Score Differential</H3>
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div>
           <Label>Adjusted Gross Score:</Label>
           <Input

--- a/components/round/calculation/courseHcpCalculationDisplay.tsx
+++ b/components/round/calculation/courseHcpCalculationDisplay.tsx
@@ -25,7 +25,7 @@ const CourseHandicapCalculationDisplay = () => {
         <H3>Course Handicap</H3>
       </div>
       <Muted>Enter 18 hole values</Muted>
-      <div className="grid grid-cols-1 md:grid-cols-5 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-5 gap-4 md:flex items-end">
         <div>
           <Label>Handicap Index</Label>
           <Input


### PR DESCRIPTION
## What was done
- Fixed an issue with the labels of the input fields for the calculations on the round calculation page

## How to test
- Go to a round calculation page
- Test the responsivity of the input fields on smaller devices

## Future work
- None