### PR TITLE
fix: round display fixes

### DIFF
--- a/components/charts/handicap-trend-chart-display.tsx
+++ b/components/charts/handicap-trend-chart-display.tsx
@@ -62,14 +62,14 @@ const HandicapTrendChartDisplay = ({
         </div>
       </CardHeader>
       <CardContent className="p-0 lg:min-h-[300px] flex justify-center items-center">
-        {previousHandicaps.length <= 5 && (
+        {previousHandicaps.length < 5 && (
           <div className="flex justify-center items-center h-full">
             <span className="text-primary">
               Play at least 5 rounds to see your scores
             </span>
           </div>
         )}
-        {previousHandicaps.length > 5 && (
+        {previousHandicaps.length >= 5 && (
           <div className="w-full h-full pt-8 pr-8">
             <HandicapTrendChart
               previousHandicaps={previousHandicaps}

--- a/components/charts/score-bar-chart.tsx
+++ b/components/charts/score-bar-chart.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { H4 } from "../ui/typography";
+import { H4, Muted } from "../ui/typography";
 import { Button } from "../ui/button";
 
 import { CartesianGrid, XAxis, Bar, BarChart, YAxis, Cell } from "recharts";
@@ -10,6 +10,7 @@ import {
   ChartTooltip,
   ChartContainer,
 } from "@/components/ui/chart";
+import { RefreshCcw } from "lucide-react";
 
 interface ScoreBarChartProps {
   scores: {
@@ -17,13 +18,14 @@ interface ScoreBarChartProps {
     score: number;
     influencesHcp?: boolean;
   }[];
+  className?: string;
 }
 
-const ScoreBarChart = ({ scores }: ScoreBarChartProps) => {
+const ScoreBarChart = ({ scores, className }: ScoreBarChartProps) => {
   return (
     <>
       {scores.length !== 0 && (
-        <div className="aspect-[16/9]">
+        <div className={`aspect-[16/9] ${className}`}>
           <ChartContainer
             config={{
               round: {
@@ -72,6 +74,14 @@ const ScoreBarChart = ({ scores }: ScoreBarChartProps) => {
               </Bar>
             </BarChart>
           </ChartContainer>
+        </div>
+      )}
+      {className === "hidden sm:block" && scores.length !== 0 && (
+        <div className={`flex justify-center mt-4 sm:hidden p-8`}>
+          <Muted className="flex items-center">
+            <RefreshCcw className="mr-2" />
+            Rotate your device to view the chart
+          </Muted>
         </div>
       )}
 

--- a/components/charts/score-bar-chat-display.tsx
+++ b/components/charts/score-bar-chat-display.tsx
@@ -29,14 +29,14 @@ const ScoreBarChartDisplay = ({
         <CardTitle className="sm:text-2xl text-xl">Previous Scores</CardTitle>
       </CardHeader>
       <CardContent className="p-0 lg:min-h-[300px] justify-center flex items-center">
-        {previousScores.length <= 5 && (
+        {previousScores.length < 5 && (
           <div className="flex justify-center items-center h-full">
             <span className="text-primary">
               Play at least 5 rounds to see your scores
             </span>
           </div>
         )}
-        {previousScores.length > 5 && (
+        {previousScores.length >= 5 && (
           <div className="w-full h-full pt-8 pr-8">
             <ScoreBarChart scores={previousScores} />
           </div>

--- a/components/dashboard/dashboardGraphDisplay.tsx
+++ b/components/dashboard/dashboardGraphDisplay.tsx
@@ -18,19 +18,7 @@ const DashboardGraphDisplay = ({ graphData }: DashboardGraphDisplayProps) => {
           </Button>
         </Link>
       </div>
-      {graphData.length !== 0 && <ScoreBarChart scores={graphData} />}
-      {graphData.length === 0 && (
-        <div className="flex items-center justify-center h-64 xl:h-[90%] border border-gray-100 flex-col">
-          <H4>No rounds found</H4>
-          <Link
-            href={`/rounds/add`}
-            className="text-primary underline mt-4"
-            prefetch={false}
-          >
-            <Button variant={"secondary"}>Add a round here</Button>
-          </Link>
-        </div>
-      )}
+      <ScoreBarChart scores={graphData} className="hidden sm:block" />
     </div>
   );
 };

--- a/components/homepage/home-page.tsx
+++ b/components/homepage/home-page.tsx
@@ -54,7 +54,7 @@ export const HomePage = async ({ profile }: HomepageProps) => {
       .sort((a, b) => {
         return new Date(a.teeTime).getTime() - new Date(b.teeTime).getTime();
       })
-      .slice(10, 20)
+      .slice(-10)
       .map((round) => ({
         roundDate: new Date(round.teeTime).toLocaleDateString(),
         score: round.adjustedGrossScore,


### PR DESCRIPTION
## What was done
- Fixed a bug where rounds weren't displayed on the homepage
- Dashboard graph display on mobile view requires landscape orientation
- Added a `className` prop to `score-bar-chart.tsx` to accommodate mobile views

## How to test
- Visit the dashboard
- See that on smaller views, there is a prompt to rotate the phone

## Future work
- None