### PR TITLE
✨ feat: reset password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ next-env.d.ts
 .env
 
 handicappin.code-workspace
+
+.env.development
+
+.env.production

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -67,8 +67,6 @@ export default function ForgotPasswordPage() {
       const PROJECT_ID = process.env.NEXT_PUBLIC_SUPABASE_URL;
       const URL = `${PROJECT_ID}/functions/v1/reset-password`;
 
-      console.log(process.env.NEXT_PUBLIC_VERCEL_URL);
-
       const resetLink = `${process.env.NEXT_PUBLIC_VERCEL_URL}/update-password`;
 
       await fetch(URL, {

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -16,15 +16,32 @@ import { z } from "zod";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { CardDescription } from "@/components/ui/card";
+import { createClientComponentClient } from "@/utils/supabase/client";
 
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState<string>("");
   const [loading, setLoading] = useState(false);
+  const supabase = createClientComponentClient();
 
   const handleSubmit = async (values: z.infer<typeof forgotPasswordSchema>) => {
     setLoading(true);
 
-    // TODO: Check is email is registered
+    const { error } = await supabase
+      .from("Profile")
+      .select("email")
+      .eq("email", values.email)
+      .single();
+
+    if (error) {
+      toast({
+        title: "No user found",
+        description:
+          "We could not find a user with that email, try a different email or contact us for help.",
+        variant: "destructive",
+      });
+      setLoading(false);
+      return;
+    }
 
     const PROJECT_ID = process.env.NEXT_PUBLIC_SUPABASE_URL;
     const URL = `${PROJECT_ID}/functions/v1/reset-password`;

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -67,12 +67,9 @@ export default function ForgotPasswordPage() {
       const PROJECT_ID = process.env.NEXT_PUBLIC_SUPABASE_URL;
       const URL = `${PROJECT_ID}/functions/v1/reset-password`;
 
-      console.log(process.env.VERCEL_ENV);
-      console.log(process.env.NEXT_PUBLIC_URL);
       console.log(process.env.NEXT_PUBLIC_VERCEL_URL);
-      console.log(process.env.VERCEL_URL);
 
-      const resetLink = `${process.env.NEXT_PUBLIC_URL}/update-password`;
+      const resetLink = `${process.env.NEXT_PUBLIC_VERCEL_URL}/update-password`;
 
       await fetch(URL, {
         method: "POST",

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -68,10 +68,11 @@ export default function ForgotPasswordPage() {
       const URL = `${PROJECT_ID}/functions/v1/reset-password`;
 
       console.log(process.env.VERCEL_ENV);
+      console.log(process.env.NEXT_PUBLIC_URL);
       console.log(process.env.NEXT_PUBLIC_VERCEL_URL);
       console.log(process.env.VERCEL_URL);
 
-      const resetLink = `${process.env.NEXT_PUBLIC_VERCEL_URL}/update-password`;
+      const resetLink = `${process.env.NEXT_PUBLIC_URL}/update-password`;
 
       await fetch(URL, {
         method: "POST",

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -67,7 +67,11 @@ export default function ForgotPasswordPage() {
       const PROJECT_ID = process.env.NEXT_PUBLIC_SUPABASE_URL;
       const URL = `${PROJECT_ID}/functions/v1/reset-password`;
 
-      const resetLink = `${process.env.NEXT_PUBLIC_APP_URL}/update-password`;
+      console.log(process.env.VERCEL_ENV);
+      console.log(process.env.NEXT_PUBLIC_VERCEL_URL);
+      console.log(process.env.VERCEL_URL);
+
+      const resetLink = `${process.env.NEXT_PUBLIC_VERCEL_URL}/update-password`;
 
       await fetch(URL, {
         method: "POST",

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { toast } from "@/components/ui/use-toast";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { CardDescription } from "@/components/ui/card";
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState<string>("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (values: z.infer<typeof forgotPasswordSchema>) => {
+    setLoading(true);
+
+    // TODO: Check is email is registered
+
+    const PROJECT_ID = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const URL = `${PROJECT_ID}/functions/v1/reset-password`;
+
+    const resetLink = `${process.env.NEXT_PUBLIC_APP_URL}/update-password`;
+
+    const response = await fetch(URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY}`,
+      },
+      body: JSON.stringify({
+        email: values.email,
+        resetLinkBase: resetLink,
+      }),
+    });
+
+    toast({
+      title: "✅ Password reset requested",
+      description: "An email has been sent to you to reset your password",
+    });
+
+    if (!response.ok) {
+      const { error } = await response.json();
+      toast({
+        title: "Error",
+        description: error || "Failed to send password reset link.",
+        variant: "destructive",
+      });
+      setLoading(false);
+      throw new Error(error || "Failed to call edge function.");
+    }
+
+    setLoading(false);
+  };
+
+  const forgotPasswordSchema = z.object({
+    email: z.string(),
+  });
+
+  const form = useForm<z.infer<typeof forgotPasswordSchema>>({
+    resolver: zodResolver(forgotPasswordSchema),
+    defaultValues: {
+      email: email,
+    },
+  });
+
+  return (
+    <div className="mx-auto max-w-sm space-y-6 py-8 sm:min-w-[40%] min-h-full w-[90%]">
+      <div className="space-y-2 text-left">
+        <h1 className="text-3xl font-bold">Reset Password</h1>
+        <CardDescription>
+          Enter your email to receive a password reset link.
+        </CardDescription>
+      </div>
+      <div className="space-y-4">
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(handleSubmit)}
+            className="space-y-8"
+          >
+            <div className="space-y-2">
+              <FormField
+                control={form.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Email</FormLabel>
+                    <FormControl>
+                      <Input
+                        id="email"
+                        type="email"
+                        required
+                        {...field}
+                        value={email}
+                        onChange={(e) => {
+                          setEmail(e.target.value);
+                          form.setValue("email", e.target.value);
+                        }}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? "Sending link..." : "Request link"}
+            </Button>
+          </form>
+        </Form>
+      </div>
+    </div>
+  );
+}

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -20,9 +20,11 @@ import { CardDescription } from "@/components/ui/card";
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState<string>("");
   const [loading, setLoading] = useState(false);
+  const [submitButtonText, setSubmitButtonText] = useState("Request link");
 
   const handleSubmit = async (values: z.infer<typeof forgotPasswordSchema>) => {
     setLoading(true);
+    setSubmitButtonText("Checking email exists...");
 
     try {
       const checkEmailResponse = await fetch(
@@ -46,10 +48,9 @@ export default function ForgotPasswordPage() {
           variant: "destructive",
         });
         setLoading(false);
+        setSubmitButtonText("Requeset link");
         return;
       }
-
-      setLoading(false);
     } catch (error) {
       toast({
         title: "Error",
@@ -58,9 +59,11 @@ export default function ForgotPasswordPage() {
         variant: "destructive",
       });
       setLoading(false);
+      setSubmitButtonText("Requeset link");
     }
 
     try {
+      setSubmitButtonText("Sending email...");
       const PROJECT_ID = process.env.NEXT_PUBLIC_SUPABASE_URL;
       const URL = `${PROJECT_ID}/functions/v1/reset-password`;
 
@@ -84,6 +87,7 @@ export default function ForgotPasswordPage() {
       });
 
       setLoading(false);
+      setSubmitButtonText("Request link");
     } catch (error) {
       toast({
         title: "Error",
@@ -94,6 +98,7 @@ export default function ForgotPasswordPage() {
       setLoading(false);
     }
     setLoading(false);
+    setSubmitButtonText("Request link");
   };
 
   const forgotPasswordSchema = z.object({

--- a/app/update-password/page.tsx
+++ b/app/update-password/page.tsx
@@ -1,35 +1,19 @@
 import UpdatePassword from "@/components/profile/update-password";
-import { createServerComponentClient } from "@/utils/supabase/server";
 import { redirect } from "next/navigation";
 
 const UpdatePasswordPage = async ({
   searchParams,
 }: {
-  searchParams: { token?: string };
+  searchParams: { token?: string; email?: string };
 }) => {
-  const supabase = createServerComponentClient();
+  const { email, token } = searchParams;
 
-  const token = searchParams.token;
   console.log(token);
   if (!token) {
-    console.log("Invalid token");
     redirect("/forgot-password");
   }
-
-  // Get user from token
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    console.log("No user found");
-    redirect("/forgot-password");
-  }
-
-  const email = user?.email;
 
   if (!email) {
-    console.log("No email found");
     redirect("/forgot-password");
   }
 

--- a/app/update-password/page.tsx
+++ b/app/update-password/page.tsx
@@ -10,7 +10,9 @@ const UpdatePasswordPage = async ({
   const supabase = createServerComponentClient();
 
   const token = searchParams.token;
+  console.log(token);
   if (!token) {
+    console.log("Invalid token");
     redirect("/forgot-password");
   }
 
@@ -20,12 +22,14 @@ const UpdatePasswordPage = async ({
   } = await supabase.auth.getUser();
 
   if (!user) {
+    console.log("No user found");
     redirect("/forgot-password");
   }
 
   const email = user?.email;
 
   if (!email) {
+    console.log("No email found");
     redirect("/forgot-password");
   }
 

--- a/app/update-password/page.tsx
+++ b/app/update-password/page.tsx
@@ -1,0 +1,35 @@
+import UpdatePassword from "@/components/profile/update-password";
+import { createServerComponentClient } from "@/utils/supabase/server";
+import { redirect } from "next/navigation";
+
+const UpdatePasswordPage = async ({
+  searchParams,
+}: {
+  searchParams: { token?: string };
+}) => {
+  const supabase = createServerComponentClient();
+
+  const token = searchParams.token;
+  if (!token) {
+    redirect("/forgot-password");
+  }
+
+  // Get user from token
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/forgot-password");
+  }
+
+  const email = user?.email;
+
+  if (!email) {
+    redirect("/forgot-password");
+  }
+
+  return <UpdatePassword token={token} email={email} />;
+};
+
+export default UpdatePasswordPage;

--- a/components/profile/update-password.tsx
+++ b/components/profile/update-password.tsx
@@ -1,0 +1,191 @@
+"use client";
+import { createClientComponentClient } from "@/utils/supabase/client";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { toast } from "../ui/use-toast";
+import { z } from "zod";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { CardDescription } from "../ui/card";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "../ui/form";
+import { Input } from "../ui/input";
+import { Button } from "../ui/button";
+
+interface UpdatePasswordProps {
+  token: string;
+  email: string;
+}
+
+const UpdatePassword = ({ token, email }: UpdatePasswordProps) => {
+  const [loading, setLoading] = useState(false);
+  const supabase = createClientComponentClient();
+  const [password, setPassword] = useState<string>("");
+  const [confirmPassword, setConfirmPassword] = useState<string>("");
+
+  const handleSubmit = async (values: z.infer<typeof forgotPasswordSchema>) => {
+    setLoading(true);
+
+    if (!token || !password) {
+      toast({
+        title: "Error",
+        description: "Token or password is missing",
+        variant: "destructive",
+      });
+      setLoading(false);
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      toast({
+        title: "Error",
+        description: "Passwords do not match",
+        variant: "destructive",
+      });
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const { error } = await supabase.auth.updateUser({
+        password: values.password,
+      });
+
+      if (error) {
+        toast({
+          title: "Error",
+          description: error.message,
+          variant: "destructive",
+        });
+      } else {
+        toast({
+          title: "✅ Success",
+          description: "Password updated successfully!",
+        });
+        setLoading(false);
+      }
+    } catch (err: any) {
+      toast({
+        title: "Error",
+        description: err.message,
+        variant: "destructive",
+      });
+    }
+    setLoading(false);
+  };
+
+  const forgotPasswordSchema = z.object({
+    email: z.string(),
+    password: z.string(),
+    confirmPassword: z.string(),
+  });
+
+  const form = useForm<z.infer<typeof forgotPasswordSchema>>({
+    resolver: zodResolver(forgotPasswordSchema),
+    defaultValues: {
+      email: email,
+    },
+  });
+
+  return (
+    <div className="mx-auto max-w-sm space-y-6 py-8 sm:min-w-[40%] min-h-full w-[90%]">
+      <div className="space-y-2 text-left">
+        <h1 className="text-3xl font-bold">Update Password</h1>
+        <CardDescription>Enter your new password to update it</CardDescription>
+      </div>
+      <div className="space-y-4">
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(handleSubmit)}
+            className="space-y-8"
+          >
+            <div className="space-y-2">
+              <FormField
+                control={form.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Email</FormLabel>
+                    <FormControl>
+                      <Input
+                        id="email"
+                        type="email"
+                        required
+                        {...field}
+                        value={email}
+                        disabled
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <div className="space-y-2">
+              <FormField
+                control={form.control}
+                name="password"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>New Password</FormLabel>
+                    <FormControl>
+                      <Input
+                        id="password"
+                        type="password"
+                        required
+                        {...field}
+                        value={password}
+                        onChange={(e) => {
+                          setPassword(e.target.value);
+                          form.setValue("password", e.target.value);
+                        }}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <div className="space-y-2">
+              <FormField
+                control={form.control}
+                name="confirmPassword"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Confirm Password</FormLabel>
+                    <FormControl>
+                      <Input
+                        id="confirmPassword"
+                        type="password"
+                        required
+                        {...field}
+                        value={confirmPassword}
+                        onChange={(e) => {
+                          setConfirmPassword(e.target.value);
+                          form.setValue("confirmPassword", e.target.value);
+                        }}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? "Updating..." : "Update password"}
+            </Button>
+          </form>
+        </Form>
+      </div>
+    </div>
+  );
+};
+
+export default UpdatePassword;

--- a/components/profile/update-password.tsx
+++ b/components/profile/update-password.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { createClientComponentClient } from "@/utils/supabase/client";
-import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { toast } from "../ui/use-toast";
 import { z } from "zod";

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
     "geist": "^1.3.1",
+    "jose": "^5.9.6",
     "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.400.0",
     "next": "14.2.4",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
     "geist": "^1.3.1",
+    "jsonwebtoken": "^9.0.2",
     "lucide-react": "^0.400.0",
     "next": "14.2.4",
     "next-themes": "^0.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       geist:
         specifier: ^1.3.1
         version: 1.3.1(next@14.2.4(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      jsonwebtoken:
+        specifier: ^9.0.2
+        version: 9.0.2
       lucide-react:
         specifier: ^0.400.0
         version: 0.400.0(react@18.3.1)
@@ -1785,6 +1788,9 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
@@ -2079,6 +2085,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   editorconfig@1.0.4:
     resolution: {integrity: sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==}
@@ -2691,9 +2700,19 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonwebtoken@9.0.2:
+    resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
+    engines: {node: '>=12', npm: '>=6'}
+
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  jwa@1.4.1:
+    resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==}
+
+  jws@3.2.2:
+    resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -2727,8 +2746,29 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.includes@4.3.0:
+    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isboolean@3.0.3:
+    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
+
+  lodash.isinteger@4.0.4:
+    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
+
+  lodash.isnumber@3.0.3:
+    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
+  lodash.isstring@4.0.1:
+    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.once@4.1.1:
+    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
@@ -5219,6 +5259,8 @@ snapshots:
       node-releases: 2.0.18
       update-browserslist-db: 1.1.1(browserslist@4.24.2)
 
+  buffer-equal-constant-time@1.0.1: {}
+
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
@@ -5503,6 +5545,10 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
   editorconfig@1.0.4:
     dependencies:
       '@one-ini/wasm': 0.1.1
@@ -5710,7 +5756,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.0(eslint@8.57.1)
       eslint-plugin-react: 7.36.1(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
@@ -5735,20 +5781,20 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.11.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.11.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
+  eslint-module-utils@2.11.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -5759,7 +5805,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
+  eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -5770,7 +5816,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.11.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -6327,12 +6373,36 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonwebtoken@9.0.2:
+    dependencies:
+      jws: 3.2.2
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.6.3
+
   jsx-ast-utils@3.3.5:
     dependencies:
       array-includes: 3.1.8
       array.prototype.flat: 1.3.2
       object.assign: 4.1.5
       object.values: 1.2.0
+
+  jwa@1.4.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@3.2.2:
+    dependencies:
+      jwa: 1.4.1
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -6361,7 +6431,21 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.includes@4.3.0: {}
+
+  lodash.isboolean@3.0.3: {}
+
+  lodash.isinteger@4.0.4: {}
+
+  lodash.isnumber@3.0.3: {}
+
+  lodash.isplainobject@4.0.6: {}
+
+  lodash.isstring@4.0.1: {}
+
   lodash.merge@4.6.2: {}
+
+  lodash.once@4.1.1: {}
 
   lodash@4.17.21: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       geist:
         specifier: ^1.3.1
         version: 1.3.1(next@14.2.4(@babel/core@7.24.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      jose:
+        specifier: ^5.9.6
+        version: 5.9.6
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
@@ -2660,6 +2663,9 @@ packages:
 
   jose@4.15.9:
     resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
+
+  jose@5.9.6:
+    resolution: {integrity: sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==}
 
   js-beautify@1.15.1:
     resolution: {integrity: sha512-ESjNzSlt/sWE8sciZH8kBF8BPlwXPwhR6pWKAw8bw4Bwj+iZcnKW6ONWUutJ7eObuBZQpiIb8S7OYspWrKt7rA==}
@@ -6342,6 +6348,8 @@ snapshots:
   jiti@1.21.6: {}
 
   jose@4.15.9: {}
+
+  jose@5.9.6: {}
 
   js-beautify@1.15.1:
     dependencies:

--- a/server/api/routers/auth.ts
+++ b/server/api/routers/auth.ts
@@ -26,7 +26,6 @@ export const authRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      console.log("User ID: " + input.id);
       const { data: profileData, error: profileError } = await ctx.supabase
         .from("Profile")
         .update({
@@ -36,13 +35,7 @@ export const authRouter = createTRPCRouter({
         .eq("id", input.id)
         .select();
 
-      console.log("---------Profile Data: ----------");
-      console.log("\n");
-      console.log(profileData);
-
       if (profileError) {
-        console.log("------------Profile Error: -----------");
-        console.log("\n");
         console.log(profileError);
         throw new Error(`Error updating profile: ${profileError.message}`);
       }

--- a/supabase/functions/check-email/index.ts
+++ b/supabase/functions/check-email/index.ts
@@ -1,0 +1,79 @@
+// Follow this setup guide to integrate the Deno language server with your editor:
+// https://deno.land/manual/getting_started/setup_your_environment
+// This enables autocomplete, go to definition, etc.
+
+// Setup type definitions for built-in Supabase Runtime APIs
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js";
+
+export const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, {
+      headers: {
+        ...corsHeaders,
+      },
+      status: 204, // No content for preflight responses
+    });
+  }
+
+  if (req.method !== "POST") {
+    return new Response(JSON.stringify({ error: "Method not allowed" }), {
+      status: 405,
+      headers: { "Content-Type": "application/json", ...corsHeaders },
+    });
+  }
+
+  const { email } = await req.json();
+
+  if (!email) {
+    return new Response(JSON.stringify({ error: "Email is required" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json", ...corsHeaders },
+    });
+  }
+
+  const supabase = createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
+  );
+
+  const { data, error } = await supabase
+    .from("Profile")
+    .select("email")
+    .eq("email", email)
+    .single();
+
+  console.log(data);
+
+  if (error) {
+    console.error(error);
+    return new Response(JSON.stringify({ exists: false }), {
+      status: 200,
+      headers: { "Content-Type": "application/json", ...corsHeaders },
+    });
+  }
+
+  return new Response(JSON.stringify({ exists: !!data }), {
+    status: 200,
+    headers: { "Content-Type": "application/json", ...corsHeaders },
+  });
+});
+
+/* To invoke locally:
+
+  1. Run `supabase start` (see: https://supabase.com/docs/reference/cli/supabase-start)
+  2. Make an HTTP request:
+
+  curl -i --location --request POST 'http://127.0.0.1:54321/functions/v1/check-email' \
+    --header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0' \
+    --header 'Content-Type: application/json' \
+    --data '{"name":"Functions"}'
+
+*/

--- a/supabase/functions/reset-password/email.tsx
+++ b/supabase/functions/reset-password/email.tsx
@@ -1,0 +1,53 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Text,
+  Tailwind,
+  Button,
+  Section,
+} from "https://esm.sh/@react-email/components@0.0.22";
+import * as React from "https://esm.sh/react@18.2.0";
+
+interface EmailProps {
+  resetLink: string;
+  username: string;
+}
+
+export const Email = ({ resetLink, username }: EmailProps) => {
+  return (
+    <Html>
+      <Head />
+      <Tailwind>
+        <Body className="bg-white my-auto mx-auto font-sans px-2">
+          <Container className="border border-solid border-[#eaeaea] rounded my-[40px] mx-auto p-[20px] max-w-[465px]">
+            <Heading className="text-black text-[24px] font-normal text-center p-0 my-[30px] mx-0">
+              Reset Password Request
+            </Heading>
+            <Text className="text-black text-[14px] leading-[24px]">
+              Hello {username},
+            </Text>
+            <Text className="text-black text-[14px] leading-[24px]">
+              A request was made to reset the password for your account on{" "}
+              {new Date().toLocaleString()}. If you did not make this request,
+              you can safely ignore this email. Click the button below to reset
+              your password:
+            </Text>
+            <Section className="text-center mt-[32px] mb-[32px]">
+              <Button
+                className="bg-[#000000] rounded text-white text-[12px] font-semibold no-underline text-center px-5 py-3"
+                href={`${resetLink}`}
+              >
+                Reset your password
+              </Button>
+            </Section>
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};
+
+export default Email;

--- a/supabase/functions/reset-password/index.ts
+++ b/supabase/functions/reset-password/index.ts
@@ -58,6 +58,7 @@ serve(async (req) => {
       const payload = {
         user_id: user.id,
         exp: getNumericDate(60 * 60), // 1 hour expiration
+        type: "password-reset",
       };
 
       token = await create({ alg: "HS256", typ: "JWT" }, payload, key);

--- a/supabase/functions/reset-password/index.ts
+++ b/supabase/functions/reset-password/index.ts
@@ -1,0 +1,92 @@
+import { createClient } from "jsr:@supabase/supabase-js@2";
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { Resend } from "https://esm.sh/resend@4.0.0";
+import ResetPasswordEmail from "./email.tsx";
+import { render } from "https://esm.sh/@react-email/components@0.0.22";
+import { create, getNumericDate } from "https://deno.land/x/djwt@v2.4/mod.ts";
+
+const supabase = createClient(
+  Deno.env.get("SUPABASE_URL")!,
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
+);
+const resend = new Resend(Deno.env.get("RESEND_API_KEY")!);
+const JWT_SECRET = Deno.env.get("RESET_TOKEN_SECRET")!;
+
+export const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, apikey, content-type",
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders, status: 204 });
+  }
+
+  if (req.method !== "POST") {
+    return new Response("Method not allowed", {
+      status: 405,
+      headers: corsHeaders,
+    });
+  }
+
+  try {
+    const { email, resetLinkBase } = await req.json();
+    if (!email) throw new Error("Email is required");
+
+    const { data: user, error } = await supabase
+      .from("Profile")
+      .select("id")
+      .eq("email", email)
+      .single();
+
+    if (error || !user) {
+      console.error(error);
+      throw new Error("User not found");
+    }
+
+    let token = "";
+
+    const key = await crypto.subtle.importKey(
+      "raw", // Key format
+      new TextEncoder().encode(JWT_SECRET), // Convert JWT_SECRET to Uint8Array
+      { name: "HMAC", hash: "SHA-256" }, // Algorithm settings
+      false, // Whether the key is extractable
+      ["sign", "verify"] // Key usage
+    );
+
+    try {
+      const payload = {
+        user_id: user.id,
+        exp: getNumericDate(60 * 60), // 1 hour expiration
+      };
+
+      token = await create({ alg: "HS256", typ: "JWT" }, payload, key);
+    } catch (error) {
+      console.error("Error creating token:", error);
+      throw new Error("Error creating token");
+    }
+
+    const resetLink = `${resetLinkBase}?token=${token}`;
+
+    const emailHtml = render(
+      ResetPasswordEmail({ resetLink, username: email })
+    );
+
+    await resend.emails.send({
+      from: "Handicappin' <sebastiansole@handicappin.com>",
+      to: email,
+      subject: "Reset Password Request",
+      html: emailHtml,
+    });
+
+    return new Response("Password reset email sent", {
+      status: 200,
+      headers: corsHeaders,
+    });
+  } catch (error) {
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 400,
+      headers: corsHeaders,
+    });
+  }
+});

--- a/supabase/functions/reset-password/index.ts
+++ b/supabase/functions/reset-password/index.ts
@@ -58,7 +58,8 @@ serve(async (req) => {
       const payload = {
         user_id: user.id,
         exp: getNumericDate(60 * 60), // 1 hour expiration
-        type: "password-reset",
+        metadata: { type: "password-reset" }, // Nest type within metadata
+        email: email,
       };
 
       token = await create({ alg: "HS256", typ: "JWT" }, payload, key);

--- a/supabase/functions/update-password/index.ts
+++ b/supabase/functions/update-password/index.ts
@@ -1,0 +1,110 @@
+// Follow this setup guide to integrate the Deno language server with your editor:
+// https://deno.land/manual/getting_started/setup_your_environment
+// This enables autocomplete, go to definition, etc.
+
+// Setup type definitions for built-in Supabase Runtime APIs
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import {
+  create,
+  verify,
+  getNumericDate,
+} from "https://deno.land/x/djwt/mod.ts";
+import { createClient } from "jsr:@supabase/supabase-js@2";
+
+const supabase = createClient(
+  Deno.env.get("SUPABASE_URL")!,
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!
+);
+
+const JWT_SECRET = Deno.env.get("RESET_TOKEN_SECRET")!;
+
+export const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, apikey, content-type",
+};
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders, status: 204 });
+  }
+
+  if (req.method !== "POST") {
+    return new Response("Method not allowed", {
+      status: 405,
+      headers: corsHeaders,
+    });
+  }
+
+  try {
+    const { token, password } = await req.json();
+
+    if (!token || !password) {
+      return new Response(
+        JSON.stringify({ error: "Missing token or password" }),
+        {
+          status: 400,
+          headers: corsHeaders,
+        }
+      );
+    }
+
+    // Validate the JWT
+    const key = await crypto.subtle.importKey(
+      "raw", // Key format
+      new TextEncoder().encode(JWT_SECRET), // Secret as Uint8Array
+      { name: "HMAC", hash: "SHA-256" }, // Algorithm settings
+      false, // Whether the key is extractable
+      ["verify"] // Key usage
+    );
+
+    const payload = await verify(token, key, "HS256");
+
+    if (payload.metadata.type !== "password-reset" || !payload.user_id) {
+      return new Response(JSON.stringify({ error: "Invalid token" }), {
+        status: 401,
+        headers: corsHeaders,
+      });
+    }
+
+    // Update the user's password
+    const { error } = await supabase.auth.admin.updateUserById(
+      payload.user_id,
+      {
+        password,
+      }
+    );
+
+    if (error) {
+      return new Response(JSON.stringify({ error: error.message }), {
+        status: 500,
+        headers: corsHeaders,
+      });
+    }
+
+    return new Response(
+      JSON.stringify({ message: "Password updated successfully" }),
+      {
+        status: 200,
+        headers: corsHeaders,
+      }
+    );
+  } catch (err) {
+    console.error(err);
+    return new Response(JSON.stringify({ error: "Internal server error" }), {
+      status: 500,
+      headers: corsHeaders,
+    });
+  }
+});
+
+/* To invoke locally:
+
+  1. Run `supabase start` (see: https://supabase.com/docs/reference/cli/supabase-start)
+  2. Make an HTTP request:
+
+  curl -i --location --request POST 'http://127.0.0.1:54321/functions/v1/update-password' \
+    --header 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0' \
+    --header 'Content-Type: application/json' \
+    --data '{"name":"Functions"}'
+
+*/

--- a/types/auth.ts
+++ b/types/auth.ts
@@ -11,4 +11,15 @@ export const loginSchema = z.object({
   password: z.string().min(6),
 });
 
+export const passwordResetPayloadSchema = z.object({
+  metadata: z.object({
+    type: z.literal("password-reset"),
+  }),
+  email: z.string().email(),
+  user_id: z.string(),
+  exp: z.number(),
+});
+
+export type PasswordResetPayload = z.infer<typeof passwordResetPayloadSchema>;
+
 export type signupSchema = z.infer<typeof signupSchema>;

--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -47,6 +47,7 @@ export async function updateSession(request: NextRequest) {
     "/about",
     "/api",
     "/verify-email",
+    "/forgot-password",
   ];
 
   const isPublic = publicPaths.some((path) => pathname.startsWith(path));

--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -2,6 +2,7 @@ import { Database } from "@/types/supabase";
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 import { jwtVerify } from "jose"; // Import the `jose` library
+import { PasswordResetPayload } from "@/types/auth";
 
 export async function updateSession(request: NextRequest) {
   let supabaseResponse = NextResponse.next({
@@ -64,9 +65,12 @@ export async function updateSession(request: NextRequest) {
     try {
       // Verify JWT token
       const secret = new TextEncoder().encode(process.env.RESET_TOKEN_SECRET);
-      const { payload } = await jwtVerify(resetToken, secret);
+      const { payload } = await jwtVerify<PasswordResetPayload>(
+        resetToken,
+        secret
+      );
 
-      if (payload.metadata?.type === "password-reset") {
+      if (payload.metadata.type === "password-reset") {
         // Attach decoded user info to request for further usage
         const url = request.nextUrl.clone();
         url.searchParams.set("email", payload.email);


### PR DESCRIPTION
## What was done
- Secure password reset functionality for both auth and public users
- Forgot password page which checks if email exists before sending an email with a reset link
- Update password page only accessible by users with a valid reset password JWT token (provided via email)
- Add check-email, reset-password and update-password supabase edge functions
- Updated middleware to handle /update-password so that both auth and public users can access it with a valid reset password JWT token

## How to test
- Log out, visit /forgot-password
- Submit a valid, registered email
- Open the password reset email sent
- Click the reset password button
- Check that you are redirected to /update-password with a valid JWT token
- Update your password
- Visit /login
- Login with new password

## Future work
- Evaluate the need for the check-email functionality to be in a supabase edge function, or if it can be moved to the web app