### PR TITLE
🐛 fix: tee dialog trigger

### DIFF
--- a/components/scorecard/tee-dialog.tsx
+++ b/components/scorecard/tee-dialog.tsx
@@ -60,55 +60,65 @@ export function TeeDialog({
     onOpenChange?.(open);
   };
 
+  function renderTeeButtons() {
+    if (mode === "edit") {
+      return (
+        <div className="flex gap-2 justify-between flex-wrap sm:flex-row flex-col">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-10 hidden md:flex"
+            disabled={disabled}
+          >
+            <Pencil className="h-4 w-4" />
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="lg"
+            className="h-10 sm:flex md:hidden "
+            disabled={disabled}
+          >
+            <Pencil className="h-4 w-4 mr-2" />
+            Edit Tee
+          </Button>
+        </div>
+      );
+    } else {
+      return (
+        <div className="flex gap-2 justify-between flex-wrap sm:flex-row flex-col">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-10 hidden  md:flex"
+            disabled={disabled}
+          >
+            <Plus className="h-4 w-4" />
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="lg"
+            className="h-10  sm:flex md:hidden"
+            disabled={disabled}
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            Add Tee
+          </Button>
+        </div>
+      );
+    }
+  }
+
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
-      <DialogTrigger asChild>
-        {mode === "edit" ? (
-          <div className="flex gap-2 justify-between flex-wrap sm:flex-row flex-col">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="h-10 hidden md:flex"
-              disabled={disabled}
-            >
-              <Pencil className="h-4 w-4" />
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="lg"
-              className="h-10 sm:flex md:hidden "
-              disabled={disabled}
-            >
-              <Pencil className="h-4 w-4 mr-2" />
-              Edit Tee
-            </Button>
-          </div>
-        ) : (
-          <div className="flex gap-2 justify-between flex-wrap sm:flex-row flex-col">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="h-10 hidden  md:flex"
-              disabled={disabled}
-            >
-              <Plus className="h-4 w-4" />
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="lg"
-              className="h-10  sm:flex md:hidden"
-              disabled={disabled}
-            >
-              <Plus className="h-4 w-4 mr-2" />
-              Add Tee
-            </Button>
-          </div>
-        )}
-      </DialogTrigger>
+      {!disabled ? (
+        <DialogTrigger asChild>{renderTeeButtons()}</DialogTrigger>
+      ) : (
+        renderTeeButtons()
+      )}
       <DialogContent className="max-w-[300px] sm:max-w-[400px] md:max-w-[600px] max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 cursor-pointer",
       className
     )}
     {...props}


### PR DESCRIPTION
## What was done

- Fixed an issue where the tee dialog trigger would execute even when the button was disabled
- Select trigger for number of holes field has cursor pointer for improved UI

## How to test

- Go to localhost:3000/rounds/add
- Try to click on add tee or edit tee button without a course selected
- See that it does not trigger the dialog

## Future work
- None