### PR TITLE
🐛 fix: duplicate user signup toast

### DIFF
--- a/components/auth/signup.tsx
+++ b/components/auth/signup.tsx
@@ -54,6 +54,17 @@ export function Signup({
       router.push("/login");
     } catch (error: any) {
       console.error("Error during sign up:", error);
+      if (
+        error.message.includes(
+          `duplicate key value violates unique constraint "profile_email_key"`
+        )
+      ) {
+        toast({
+          title: "Error signing up",
+          description: "Email already in use. Please login.",
+        });
+        return;
+      }
       toast({
         title: "Error signing up",
         description: error.message || "An error occurred during sign up.",


### PR DESCRIPTION
## What was done

- Updated the toast description for an error when a user tried to sign up with an email that already was in use

## How to test

- Sign up a user
- Try to sign up another user with the same email

## Future work
- Replace all toasts with better UX solutions
