### PR TITLE
🗃️ db: add country to course table

### DIFF
--- a/components/scorecard/add-course-dialog.tsx
+++ b/components/scorecard/add-course-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { CountryCombobox } from "@/components/scorecard/country-combobox";
 import { Plus } from "lucide-react";
 import { DialogPage, MultiPageDialog } from "../ui/multi-page-dialog";
 import { Course, courseCreationSchema } from "@/types/scorecard";
@@ -29,6 +30,7 @@ export function AddCourseDialog({ onAdd }: AddCourseDialogProps) {
     resolver: zodResolver(courseCreationSchema),
     defaultValues: {
       name: "",
+      country: "",
       approvalStatus: "pending",
       tees: [
         {
@@ -64,17 +66,19 @@ export function AddCourseDialog({ onAdd }: AddCourseDialogProps) {
   const { control, handleSubmit, watch } = form;
 
   const watchName = watch("name");
+  const watchCountry = watch("country");
   const watchTee = watch("tees.0");
 
   // Use schema validation instead of custom logic
   const isFormValid = useMemo(() => {
     const result = courseCreationSchema.safeParse({
       name: watchName,
+      country: watchCountry,
       approvalStatus: "pending",
       tees: watchTee ? [watchTee] : [],
     });
     return result.success;
-  }, [watchName, watchTee]);
+  }, [watchName, watchCountry, watchTee]);
 
   const onSubmit = (values: Course) => {
     // Schema validation is already handled by the form resolver
@@ -148,6 +152,25 @@ export function AddCourseDialog({ onAdd }: AddCourseDialogProps) {
                   <FormItem>
                     <FormControl>
                       <Input {...field} placeholder="Enter course name" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                </div>
+              )}
+            />
+            <FormField
+              control={control}
+              name="country"
+              render={({ field }) => (
+                <div className="space-y-2 py-4">
+                  <FormLabel htmlFor="country">Country</FormLabel>
+                  <FormItem>
+                    <FormControl>
+                      <CountryCombobox
+                        value={field.value}
+                        onValueChange={field.onChange}
+                        placeholder="Select a country..."
+                      />
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/components/scorecard/country-combobox.tsx
+++ b/components/scorecard/country-combobox.tsx
@@ -1,0 +1,401 @@
+"use client";
+
+import * as React from "react";
+import { Search, ChevronDown } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+const countries = [
+  { value: "afghanistan", label: "Afghanistan 🇦🇫" },
+  { value: "albania", label: "Albania 🇦🇱" },
+  { value: "algeria", label: "Algeria 🇩🇿" },
+  { value: "andorra", label: "Andorra 🇦🇩" },
+  { value: "angola", label: "Angola 🇦🇴" },
+  { value: "antigua-and-barbuda", label: "Antigua and Barbuda 🇦🇬" },
+  { value: "argentina", label: "Argentina 🇦🇷" },
+  { value: "armenia", label: "Armenia 🇦🇲" },
+  { value: "australia", label: "Australia 🇦🇺" },
+  { value: "austria", label: "Austria 🇦🇹" },
+  { value: "azerbaijan", label: "Azerbaijan 🇦🇿" },
+  { value: "bahamas", label: "Bahamas 🇧🇸" },
+  { value: "bahrain", label: "Bahrain 🇧🇭" },
+  { value: "bangladesh", label: "Bangladesh 🇧🇩" },
+  { value: "barbados", label: "Barbados 🇧🇧" },
+  { value: "belarus", label: "Belarus 🇧🇾" },
+  { value: "belgium", label: "Belgium 🇧🇪" },
+  { value: "belize", label: "Belize 🇧🇿" },
+  { value: "benin", label: "Benin 🇧🇯" },
+  { value: "bhutan", label: "Bhutan 🇧🇹" },
+  { value: "bolivia", label: "Bolivia 🇧🇴" },
+  { value: "bosnia-and-herzegovina", label: "Bosnia and Herzegovina 🇧🇦" },
+  { value: "botswana", label: "Botswana 🇧🇼" },
+  { value: "brazil", label: "Brazil 🇧🇷" },
+  { value: "brunei", label: "Brunei 🇧🇳" },
+  { value: "bulgaria", label: "Bulgaria 🇧🇬" },
+  { value: "burkina-faso", label: "Burkina Faso 🇧🇫" },
+  { value: "burundi", label: "Burundi 🇧🇮" },
+  { value: "cabo-verde", label: "Cabo Verde 🇨🇻" },
+  { value: "cambodia", label: "Cambodia 🇰🇭" },
+  { value: "cameroon", label: "Cameroon 🇨🇲" },
+  { value: "canada", label: "Canada 🇨🇦" },
+  { value: "central-african-republic", label: "Central African Republic 🇨🇫" },
+  { value: "chad", label: "Chad 🇹🇩" },
+  { value: "chile", label: "Chile 🇨🇱" },
+  { value: "china", label: "China 🇨🇳" },
+  { value: "colombia", label: "Colombia 🇨🇴" },
+  { value: "comoros", label: "Comoros 🇰🇲" },
+  {
+    value: "congo-democratic-republic",
+    label: "Congo (Democratic Republic) 🇨🇩",
+  },
+  { value: "congo-republic", label: "Congo (Republic) 🇨🇬" },
+  { value: "costa-rica", label: "Costa Rica 🇨🇷" },
+  { value: "croatia", label: "Croatia 🇭🇷" },
+  { value: "cuba", label: "Cuba 🇨🇺" },
+  { value: "cyprus", label: "Cyprus 🇨🇾" },
+  { value: "czech-republic", label: "Czech Republic 🇨🇿" },
+  { value: "denmark", label: "Denmark 🇩🇰" },
+  { value: "djibouti", label: "Djibouti 🇩🇯" },
+  { value: "dominica", label: "Dominica 🇩🇲" },
+  { value: "dominican-republic", label: "Dominican Republic 🇩🇴" },
+  { value: "ecuador", label: "Ecuador 🇪🇨" },
+  { value: "egypt", label: "Egypt 🇪🇬" },
+  { value: "el-salvador", label: "El Salvador 🇸🇻" },
+  { value: "england", label: "England 🏴󠁧󠁢󠁥󠁮󠁧󠁿" },
+  { value: "equatorial-guinea", label: "Equatorial Guinea 🇬🇶" },
+  { value: "eritrea", label: "Eritrea 🇪🇷" },
+  { value: "estonia", label: "Estonia 🇪🇪" },
+  { value: "eswatini", label: "Eswatini 🇸🇿" },
+  { value: "ethiopia", label: "Ethiopia 🇪🇹" },
+  { value: "fiji", label: "Fiji 🇫🇯" },
+  { value: "finland", label: "Finland 🇫🇮" },
+  { value: "france", label: "France 🇫🇷" },
+  { value: "gabon", label: "Gabon 🇬🇦" },
+  { value: "gambia", label: "Gambia 🇬🇲" },
+  { value: "georgia", label: "Georgia 🇬🇪" },
+  { value: "germany", label: "Germany 🇩🇪" },
+  { value: "ghana", label: "Ghana 🇬🇭" },
+  { value: "greece", label: "Greece 🇬🇷" },
+  { value: "grenada", label: "Grenada 🇬🇩" },
+  { value: "guatemala", label: "Guatemala 🇬🇹" },
+  { value: "guinea", label: "Guinea 🇬🇳" },
+  { value: "guinea-bissau", label: "Guinea-Bissau 🇬🇼" },
+  { value: "guyana", label: "Guyana 🇬🇾" },
+  { value: "haiti", label: "Haiti 🇭🇹" },
+  { value: "honduras", label: "Honduras 🇭🇳" },
+  { value: "hungary", label: "Hungary 🇭🇺" },
+  { value: "iceland", label: "Iceland 🇮🇸" },
+  { value: "india", label: "India 🇮🇳" },
+  { value: "indonesia", label: "Indonesia 🇮🇩" },
+  { value: "iran", label: "Iran 🇮🇷" },
+  { value: "iraq", label: "Iraq 🇮🇶" },
+  { value: "ireland", label: "Ireland 🇮🇪" },
+  { value: "israel", label: "Israel 🇮🇱" },
+  { value: "italy", label: "Italy 🇮🇹" },
+  { value: "jamaica", label: "Jamaica 🇯🇲" },
+  { value: "japan", label: "Japan 🇯🇵" },
+  { value: "jordan", label: "Jordan 🇯🇴" },
+  { value: "kazakhstan", label: "Kazakhstan 🇰🇿" },
+  { value: "kenya", label: "Kenya 🇰🇪" },
+  { value: "kiribati", label: "Kiribati 🇰🇮" },
+  { value: "north-korea", label: "Korea (North) 🇰🇵" },
+  { value: "south-korea", label: "Korea (South) 🇰🇷" },
+  { value: "kuwait", label: "Kuwait 🇰🇼" },
+  { value: "kyrgyzstan", label: "Kyrgyzstan 🇰🇬" },
+  { value: "laos", label: "Laos 🇱🇦" },
+  { value: "latvia", label: "Latvia 🇱🇻" },
+  { value: "lebanon", label: "Lebanon 🇱🇧" },
+  { value: "lesotho", label: "Lesotho 🇱🇸" },
+  { value: "liberia", label: "Liberia 🇱🇷" },
+  { value: "libya", label: "Libya 🇱🇾" },
+  { value: "liechtenstein", label: "Liechtenstein 🇱🇮" },
+  { value: "lithuania", label: "Lithuania 🇱🇹" },
+  { value: "luxembourg", label: "Luxembourg 🇱🇺" },
+  { value: "madagascar", label: "Madagascar 🇲🇬" },
+  { value: "malawi", label: "Malawi 🇲🇼" },
+  { value: "malaysia", label: "Malaysia 🇲🇾" },
+  { value: "maldives", label: "Maldives 🇲🇻" },
+  { value: "mali", label: "Mali 🇲🇱" },
+  { value: "malta", label: "Malta 🇲🇹" },
+  { value: "marshall-islands", label: "Marshall Islands 🇲🇭" },
+  { value: "mauritania", label: "Mauritania 🇲🇷" },
+  { value: "mauritius", label: "Mauritius 🇲🇺" },
+  { value: "mexico", label: "Mexico 🇲🇽" },
+  { value: "micronesia", label: "Micronesia 🇫🇲" },
+  { value: "moldova", label: "Moldova 🇲🇩" },
+  { value: "monaco", label: "Monaco 🇲🇨" },
+  { value: "mongolia", label: "Mongolia 🇲🇳" },
+  { value: "montenegro", label: "Montenegro 🇲🇪" },
+  { value: "morocco", label: "Morocco 🇲🇦" },
+  { value: "mozambique", label: "Mozambique 🇲🇿" },
+  { value: "myanmar", label: "Myanmar 🇲🇲" },
+  { value: "namibia", label: "Namibia 🇳🇦" },
+  { value: "nauru", label: "Nauru 🇳🇷" },
+  { value: "nepal", label: "Nepal 🇳🇵" },
+  { value: "netherlands", label: "Netherlands 🇳🇱" },
+  { value: "new-zealand", label: "New Zealand 🇳🇿" },
+  { value: "nicaragua", label: "Nicaragua 🇳🇮" },
+  { value: "niger", label: "Niger 🇳🇪" },
+  { value: "nigeria", label: "Nigeria 🇳🇬" },
+  { value: "north-macedonia", label: "North Macedonia 🇲🇰" },
+  { value: "northern-ireland", label: "Northern Ireland 🍀" },
+  { value: "norway", label: "Norway 🇳🇴" },
+  { value: "oman", label: "Oman 🇴🇲" },
+  { value: "pakistan", label: "Pakistan 🇵🇰" },
+  { value: "palau", label: "Palau 🇵🇼" },
+  { value: "palestine", label: "Palestine 🇵🇸" },
+  { value: "panama", label: "Panama 🇵🇦" },
+  { value: "papua-new-guinea", label: "Papua New Guinea 🇵🇬" },
+  { value: "paraguay", label: "Paraguay 🇵🇾" },
+  { value: "peru", label: "Peru 🇵🇪" },
+  { value: "philippines", label: "Philippines 🇵🇭" },
+  { value: "poland", label: "Poland 🇵🇱" },
+  { value: "portugal", label: "Portugal 🇵🇹" },
+  { value: "qatar", label: "Qatar 🇶🇦" },
+  { value: "romania", label: "Romania 🇷🇴" },
+  { value: "russia", label: "Russia 🇷🇺" },
+  { value: "rwanda", label: "Rwanda 🇷🇼" },
+  { value: "saint-kitts-and-nevis", label: "Saint Kitts and Nevis 🇰🇳" },
+  { value: "saint-lucia", label: "Saint Lucia 🇱🇨" },
+  {
+    value: "saint-vincent-and-the-grenadines",
+    label: "Saint Vincent and the Grenadines 🇻🇨",
+  },
+  { value: "samoa", label: "Samoa 🇼🇸" },
+  { value: "san-marino", label: "San Marino 🇸🇲" },
+  { value: "sao-tome-and-principe", label: "Sao Tome and Principe 🇸🇹" },
+  { value: "saudi-arabia", label: "Saudi Arabia 🇸🇦" },
+  { value: "scotland", label: "Scotland 🏴󠁧󠁢󠁳󠁣󠁴󠁿" },
+  { value: "senegal", label: "Senegal 🇸🇳" },
+  { value: "serbia", label: "Serbia 🇷🇸" },
+  { value: "seychelles", label: "Seychelles 🇸🇨" },
+  { value: "sierra-leone", label: "Sierra Leone 🇸🇱" },
+  { value: "singapore", label: "Singapore 🇸🇬" },
+  { value: "slovakia", label: "Slovakia 🇸🇰" },
+  { value: "slovenia", label: "Slovenia 🇸🇮" },
+  { value: "solomon-islands", label: "Solomon Islands 🇸🇧" },
+  { value: "somalia", label: "Somalia 🇸🇴" },
+  { value: "south-africa", label: "South Africa 🇿🇦" },
+  { value: "south-sudan", label: "South Sudan 🇸🇸" },
+  { value: "spain", label: "Spain 🇪🇸" },
+  { value: "sri-lanka", label: "Sri Lanka 🇱🇰" },
+  { value: "sudan", label: "Sudan 🇸🇩" },
+  { value: "suriname", label: "Suriname 🇸🇷" },
+  { value: "sweden", label: "Sweden 🇸🇪" },
+  { value: "switzerland", label: "Switzerland 🇨🇭" },
+  { value: "syria", label: "Syria 🇸🇾" },
+  { value: "taiwan", label: "Taiwan 🇹🇼" },
+  { value: "tajikistan", label: "Tajikistan 🇹🇯" },
+  { value: "tanzania", label: "Tanzania 🇹🇿" },
+  { value: "thailand", label: "Thailand 🇹🇭" },
+  { value: "timor-leste", label: "Timor-Leste 🇹🇱" },
+  { value: "togo", label: "Togo 🇹🇬" },
+  { value: "tonga", label: "Tonga 🇹🇴" },
+  { value: "trinidad-and-tobago", label: "Trinidad and Tobago 🇹🇹" },
+  { value: "tunisia", label: "Tunisia 🇹🇳" },
+  { value: "turkey", label: "Turkey 🇹🇷" },
+  { value: "turkmenistan", label: "Turkmenistan 🇹🇲" },
+  { value: "tuvalu", label: "Tuvalu 🇹🇻" },
+  { value: "uganda", label: "Uganda 🇺🇬" },
+  { value: "ukraine", label: "Ukraine 🇺🇦" },
+  { value: "united-arab-emirates", label: "United Arab Emirates 🇦🇪" },
+  { value: "united-kingdom", label: "United Kingdom 🇬🇧" },
+  { value: "united-states", label: "United States 🇺🇸" },
+  { value: "uruguay", label: "Uruguay 🇺🇾" },
+  { value: "uzbekistan", label: "Uzbekistan 🇺🇿" },
+  { value: "vanuatu", label: "Vanuatu 🇻🇺" },
+  { value: "vatican-city", label: "Vatican City 🇻🇦" },
+  { value: "venezuela", label: "Venezuela 🇻🇪" },
+  { value: "vietnam", label: "Vietnam 🇻🇳" },
+  { value: "wales", label: "Wales 🏴󠁧󠁢󠁷󠁬󠁳󠁿" },
+  { value: "yemen", label: "Yemen 🇾🇪" },
+  { value: "zambia", label: "Zambia 🇿🇲" },
+  { value: "zimbabwe", label: "Zimbabwe 🇿🇼" },
+];
+
+interface CountryComboboxProps {
+  value?: string;
+  onValueChange?: (value: string) => void;
+  placeholder?: string;
+  className?: string;
+  disabled?: boolean;
+}
+
+export function CountryCombobox({
+  value,
+  onValueChange,
+  placeholder = "Search or select a country...",
+  className,
+  disabled = false,
+}: CountryComboboxProps) {
+  const [inputValue, setInputValue] = React.useState("");
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [isFocused, setIsFocused] = React.useState(false);
+  const [highlightedIndex, setHighlightedIndex] = React.useState(-1);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  const selectedCountry = countries.find((country) => country.value === value);
+
+  // Show all countries if no search term, or filter based on search
+  const filteredCountries =
+    inputValue.trim() === ""
+      ? countries
+      : countries.filter((country) =>
+          country.label.toLowerCase().includes(inputValue.toLowerCase())
+        );
+
+  const handleCountrySelect = (country: (typeof countries)[0]) => {
+    onValueChange?.(country.value);
+    setInputValue(country.label);
+    setIsOpen(false);
+
+    // Move focus to next focusable element to continue tab navigation
+    setTimeout(() => {
+      const focusableElements = document.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      const currentIndex = Array.from(focusableElements).indexOf(
+        inputRef.current!
+      );
+      const nextElement = focusableElements[currentIndex + 1] as HTMLElement;
+      if (nextElement) {
+        nextElement.focus();
+      }
+    }, 0);
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+    setIsOpen(true);
+    setHighlightedIndex(-1);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!isOpen) return;
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setHighlightedIndex((prev) =>
+          prev < filteredCountries.length - 1 ? prev + 1 : prev
+        );
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setHighlightedIndex((prev) => (prev > 0 ? prev - 1 : -1));
+        break;
+      case "Enter":
+        e.preventDefault();
+        if (
+          highlightedIndex >= 0 &&
+          highlightedIndex < filteredCountries.length
+        ) {
+          handleCountrySelect(filteredCountries[highlightedIndex]);
+        }
+        break;
+      case "Escape":
+        e.preventDefault();
+        setIsOpen(false);
+        setHighlightedIndex(-1);
+        inputRef.current?.blur();
+        break;
+      case "Tab":
+        // Allow natural tab behavior to move to next element
+        setIsOpen(false);
+        setHighlightedIndex(-1);
+        break;
+    }
+  };
+
+  const handleInputFocus = () => {
+    setIsFocused(true);
+    setIsOpen(true);
+    // If a country is selected, clear the input to allow searching
+    if (selectedCountry) {
+      setInputValue("");
+    }
+  };
+
+  const handleInputBlur = () => {
+    setIsFocused(false);
+    // Delay to allow click on dropdown items
+    setTimeout(() => {
+      setIsOpen(false);
+      // Reset to selected country label if no selection was made
+      if (selectedCountry && !value) {
+        setInputValue(selectedCountry.label);
+      } else if (selectedCountry) {
+        setInputValue(selectedCountry.label);
+      } else {
+        setInputValue("");
+      }
+    }, 150);
+  };
+
+  // Set display value based on selection state
+  const displayValue = isFocused
+    ? inputValue
+    : selectedCountry?.label || inputValue;
+
+  return (
+    <div className="relative">
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+        <Input
+          ref={inputRef}
+          type="text"
+          placeholder={placeholder}
+          value={displayValue}
+          onChange={handleInputChange}
+          onKeyDown={handleKeyDown}
+          onFocus={handleInputFocus}
+          onBlur={handleInputBlur}
+          className={cn("pl-10 pr-10", className)}
+          disabled={disabled}
+          autoComplete="off"
+          role="combobox"
+          aria-expanded={isOpen}
+          aria-haspopup="listbox"
+        />
+        <ChevronDown className="absolute right-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+      </div>
+
+      {isOpen && (
+        <div
+          className="absolute top-full left-0 right-0 z-50 mt-1 bg-background border rounded-md shadow-lg max-h-[200px] overflow-y-auto"
+          role="listbox"
+        >
+          {filteredCountries.length > 0 ? (
+            filteredCountries.map((country, index) => (
+              <button
+                key={country.value}
+                type="button"
+                className={cn(
+                  "w-full text-left px-3 py-2 hover:bg-accent hover:text-accent-foreground text-sm border-b last:border-b-0 focus:bg-accent focus:text-accent-foreground focus:outline-none",
+                  value === country.value && "bg-accent text-accent-foreground",
+                  highlightedIndex === index && "bg-muted"
+                )}
+                onMouseDown={(e) => {
+                  // Prevent input blur when clicking on option
+                  e.preventDefault();
+                  handleCountrySelect(country);
+                }}
+                onMouseEnter={() => setHighlightedIndex(index)}
+                role="option"
+                aria-selected={value === country.value}
+              >
+                {country.label}
+              </button>
+            ))
+          ) : (
+            <div className="px-3 py-2 text-sm text-muted-foreground">
+              No countries found
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -83,6 +83,8 @@ export const course = pgTable(
     id: serial().primaryKey().notNull(),
     name: text().notNull(),
     approvalStatus: text().default("pending").notNull(),
+    country: text().default("Scotland").notNull(),
+    website: text(),
   },
   (table) => [
     uniqueIndex("course_name_key").using(

--- a/server/api/routers/course.ts
+++ b/server/api/routers/course.ts
@@ -13,7 +13,11 @@ export const courseRouter = createTRPCRouter({
     .input(z.object({ courseId: z.number() }))
     .query(async ({ ctx, input }) => {
       const { courseId } = input;
-      const { data: course, error } = await ctx.supabase.from("course").select("*").eq("id", courseId).single();
+      const { data: course, error } = await ctx.supabase
+        .from("course")
+        .select("*")
+        .eq("id", courseId)
+        .single();
       if (error) {
         console.error(error);
         return null;
@@ -43,6 +47,7 @@ export const courseRouter = createTRPCRouter({
           id: course.id,
           name: course.name,
           approvalStatus: course.approvalStatus,
+          country: course.country,
         })
         .from(course)
         .where(

--- a/server/api/routers/scorecard.ts
+++ b/server/api/routers/scorecard.ts
@@ -1,133 +1,171 @@
 import { z } from "zod";
 import { createTRPCRouter, publicProcedure } from "../trpc";
-import { eq, inArray } from 'drizzle-orm';
+import { eq, inArray } from "drizzle-orm";
 import { db } from "@/db";
 import { course, round, teeInfo, hole, score } from "@/db/schema";
 import { scorecardSchema, ScorecardWithRound } from "@/types/scorecard";
 
 export const scorecardRouter = createTRPCRouter({
-  getScorecardByRoundId: publicProcedure.input(z.object({ id: z.string() })).query(async ({ ctx, input }) => {
-    const { id } = input;
+  getScorecardByRoundId: publicProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ ctx, input }) => {
+      const { id } = input;
 
-    // Convert id to number since round.id is a number in the schema
-    const numericId = Number(id);
-    if (isNaN(numericId)) {
-      throw new Error("Invalid round id");
-    }
+      // Convert id to number since round.id is a number in the schema
+      const numericId = Number(id);
+      if (isNaN(numericId)) {
+        throw new Error("Invalid round id");
+      }
 
-    // 1. Fetch the round
-    const roundResult = await db.select().from(round).where(eq(round.id, numericId));
-    const roundData = roundResult[0];
-    if (!roundData) throw new Error("Round not found");
+      // 1. Fetch the round
+      const roundResult = await db
+        .select()
+        .from(round)
+        .where(eq(round.id, numericId));
+      const roundData = roundResult[0];
+      if (!roundData) throw new Error("Round not found");
 
-    // 2. Fetch the course
-    const courseResult = await db.select().from(course).where(eq(course.id, roundData.courseId));
-    const courseData = courseResult[0];
-    if (!courseData) throw new Error("Course not found");
+      // 2. Fetch the course
+      const courseResult = await db
+        .select()
+        .from(course)
+        .where(eq(course.id, roundData.courseId));
+      const courseData = courseResult[0];
+      if (!courseData) throw new Error("Course not found");
 
-    // 4. Fetch the tee played
-    const teePlayedResult = await db.select().from(teeInfo).where(eq(teeInfo.id, roundData.teeId));
-    const teePlayed = teePlayedResult[0];
-    if (!teePlayed) throw new Error("Tee played not found");
+      // 4. Fetch the tee played
+      const teePlayedResult = await db
+        .select()
+        .from(teeInfo)
+        .where(eq(teeInfo.id, roundData.teeId));
+      const teePlayed = teePlayedResult[0];
+      if (!teePlayed) throw new Error("Tee played not found");
 
-    // 5. Fetch holes for the tee played
-    const holes = await db.select().from(hole).where(eq(hole.teeId, teePlayed.id));
+      // 5. Fetch holes for the tee played
+      const holes = await db
+        .select()
+        .from(hole)
+        .where(eq(hole.teeId, teePlayed.id));
 
-    // 6. Fetch scores for the round
-    const scores = await db.select().from(score).where(eq(score.roundId, roundData.id));
+      // 6. Fetch scores for the round
+      const scores = await db
+        .select()
+        .from(score)
+        .where(eq(score.roundId, roundData.id));
 
-    // 7. Assemble the Scorecard object
-    const scorecard: ScorecardWithRound = {
-      userId: roundData.userId,
-      course: {
-        id: courseData.id,
-        name: courseData.name,
-        approvalStatus: courseData.approvalStatus === 'approved' ? 'approved' : 'pending',
-        tees: undefined,
-      },
-      teePlayed: {
-        ...teePlayed,
-        courseRating18: Number(teePlayed.courseRating18),
-        courseRatingFront9: Number(teePlayed.courseRatingFront9),
-        courseRatingBack9: Number(teePlayed.courseRatingBack9),
-        approvalStatus: teePlayed.approvalStatus === 'approved' ? 'approved' : 'pending',
-        distanceMeasurement: teePlayed.distanceMeasurement === 'meters' ? 'meters' : 'yards',
-        gender: teePlayed.gender === 'mens' ? 'mens' : 'ladies',
-        holes: holes,
-      },
-      scores: scores,
-      teeTime: roundData.teeTime.toISOString(),
-      approvalStatus: roundData.approvalStatus === 'approved' ? 'approved' : 'pending',
-      notes: roundData.notes || undefined,
-      round: {
-        ...roundData,
-        teeTime: roundData.teeTime.toISOString(),
-        createdAt: roundData.createdAt.toISOString(),
-      },
-    };
-
-    // Validate with zod
-    scorecardSchema.parse(scorecard);
-    return scorecard;
-  }),
-  getAllScorecardsByUserId: publicProcedure.input(z.object({ userId: z.string().uuid() })).query(async ({ ctx, input }) => {
-    const { userId } = input;
-    // 1. Fetch all rounds for the user
-    const rounds = await db.select().from(round).where(eq(round.userId, userId));
-    if (!rounds.length) return [];
-
-    // 2. Fetch all courseIds, teeIds, roundIds
-    const courseIds = Array.from(new Set(rounds.map(r => r.courseId)));
-    const teeIds = Array.from(new Set(rounds.map(r => r.teeId)));
-    const roundIds = rounds.map(r => r.id);
-
-    // 3. Fetch all related data in batches
-    const [courses, tees, allHoles, allScores] = await Promise.all([
-      db.select().from(course).where(inArray(course.id, courseIds)),
-      db.select().from(teeInfo).where(inArray(teeInfo.id, teeIds)),
-      db.select().from(hole).where(inArray(hole.teeId, teeIds)),
-      db.select().from(score).where(inArray(score.roundId, roundIds)),
-    ]);
-
-    // 4. Assemble Scorecard objects
-    const scorecards: ScorecardWithRound[] = rounds.map(roundData => {
-      const courseData = courses.find(c => c.id === roundData.courseId);
-      const teePlayed = tees.find(t => t.id === roundData.teeId);
-      if (!courseData || !teePlayed) return undefined;
-      const holes = allHoles.filter(h => h.teeId === teePlayed.id);
-      const scores = allScores.filter(s => s.roundId === roundData.id);
-      return {
+      // 7. Assemble the Scorecard object
+      const scorecard: ScorecardWithRound = {
         userId: roundData.userId,
         course: {
           id: courseData.id,
           name: courseData.name,
-          approvalStatus: courseData.approvalStatus === 'approved' ? 'approved' : 'pending',
+          approvalStatus:
+            courseData.approvalStatus === "approved" ? "approved" : "pending",
           tees: undefined,
+          country: courseData.country,
         },
         teePlayed: {
           ...teePlayed,
           courseRating18: Number(teePlayed.courseRating18),
           courseRatingFront9: Number(teePlayed.courseRatingFront9),
           courseRatingBack9: Number(teePlayed.courseRatingBack9),
-          approvalStatus: teePlayed.approvalStatus === 'approved' ? 'approved' : 'pending',
-          distanceMeasurement: teePlayed.distanceMeasurement === 'meters' ? 'meters' : 'yards',
-          gender: teePlayed.gender === 'mens' ? 'mens' : 'ladies',
+          approvalStatus:
+            teePlayed.approvalStatus === "approved" ? "approved" : "pending",
+          distanceMeasurement:
+            teePlayed.distanceMeasurement === "meters" ? "meters" : "yards",
+          gender: teePlayed.gender === "mens" ? "mens" : "ladies",
           holes: holes,
         },
         scores: scores,
         teeTime: roundData.teeTime.toISOString(),
-        approvalStatus: roundData.approvalStatus === 'approved' ? 'approved' : 'pending',
+        approvalStatus:
+          roundData.approvalStatus === "approved" ? "approved" : "pending",
         notes: roundData.notes || undefined,
         round: {
-            ...roundData,
-            teeTime: roundData.teeTime.toISOString(),
-            createdAt: roundData.createdAt.toISOString(),
-          },
+          ...roundData,
+          teeTime: roundData.teeTime.toISOString(),
+          createdAt: roundData.createdAt.toISOString(),
+        },
       };
-    }).filter(Boolean) as ScorecardWithRound[];
 
-    // Validate all with zod
-    scorecards.forEach(scorecard => scorecardSchema.parse(scorecard));
-    return scorecards;
-  }),
+      // Validate with zod
+      scorecardSchema.parse(scorecard);
+      return scorecard;
+    }),
+  getAllScorecardsByUserId: publicProcedure
+    .input(z.object({ userId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      const { userId } = input;
+      // 1. Fetch all rounds for the user
+      const rounds = await db
+        .select()
+        .from(round)
+        .where(eq(round.userId, userId));
+      if (!rounds.length) return [];
+
+      // 2. Fetch all courseIds, teeIds, roundIds
+      const courseIds = Array.from(new Set(rounds.map((r) => r.courseId)));
+      const teeIds = Array.from(new Set(rounds.map((r) => r.teeId)));
+      const roundIds = rounds.map((r) => r.id);
+
+      // 3. Fetch all related data in batches
+      const [courses, tees, allHoles, allScores] = await Promise.all([
+        db.select().from(course).where(inArray(course.id, courseIds)),
+        db.select().from(teeInfo).where(inArray(teeInfo.id, teeIds)),
+        db.select().from(hole).where(inArray(hole.teeId, teeIds)),
+        db.select().from(score).where(inArray(score.roundId, roundIds)),
+      ]);
+
+      // 4. Assemble Scorecard objects
+      const scorecards: ScorecardWithRound[] = rounds
+        .map((roundData) => {
+          const courseData = courses.find((c) => c.id === roundData.courseId);
+          const teePlayed = tees.find((t) => t.id === roundData.teeId);
+          if (!courseData || !teePlayed) return undefined;
+          const holes = allHoles.filter((h) => h.teeId === teePlayed.id);
+          const scores = allScores.filter((s) => s.roundId === roundData.id);
+          return {
+            userId: roundData.userId,
+            course: {
+              id: courseData.id,
+              name: courseData.name,
+              approvalStatus:
+                courseData.approvalStatus === "approved"
+                  ? "approved"
+                  : "pending",
+              tees: undefined,
+              country: courseData.country,
+            },
+            teePlayed: {
+              ...teePlayed,
+              courseRating18: Number(teePlayed.courseRating18),
+              courseRatingFront9: Number(teePlayed.courseRatingFront9),
+              courseRatingBack9: Number(teePlayed.courseRatingBack9),
+              approvalStatus:
+                teePlayed.approvalStatus === "approved"
+                  ? "approved"
+                  : "pending",
+              distanceMeasurement:
+                teePlayed.distanceMeasurement === "meters" ? "meters" : "yards",
+              gender: teePlayed.gender === "mens" ? "mens" : "ladies",
+              holes: holes,
+            },
+            scores: scores,
+            teeTime: roundData.teeTime.toISOString(),
+            approvalStatus:
+              roundData.approvalStatus === "approved" ? "approved" : "pending",
+            notes: roundData.notes || undefined,
+            round: {
+              ...roundData,
+              teeTime: roundData.teeTime.toISOString(),
+              createdAt: roundData.createdAt.toISOString(),
+            },
+          };
+        })
+        .filter(Boolean) as ScorecardWithRound[];
+
+      // Validate all with zod
+      scorecards.forEach((scorecard) => scorecardSchema.parse(scorecard));
+      return scorecards;
+    }),
 });

--- a/supabase/migrations/20250819170557_futuristic_terrax.sql
+++ b/supabase/migrations/20250819170557_futuristic_terrax.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "course" ADD COLUMN "country" text NOT NULL DEFAULT 'Scotland';--> statement-breakpoint
+ALTER TABLE "course" ADD COLUMN "website" text;

--- a/supabase/migrations/meta/20250819170557_snapshot.json
+++ b/supabase/migrations/meta/20250819170557_snapshot.json
@@ -1,0 +1,793 @@
+{
+  "id": "d4cf0a72-dd07-4479-96de-94e7bd018c5a",
+  "prevId": "2b52bb55-0632-44b4-93cf-5f6b08bb421e",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.course": {
+      "name": "course",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approvalStatus": {
+          "name": "approvalStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "course_name_key": {
+          "name": "course_name_key",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view courses": {
+          "name": "Authenticated users can view courses",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hole": {
+      "name": "hole",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "teeId": {
+          "name": "teeId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "holeNumber": {
+          "name": "holeNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "par": {
+          "name": "par",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance": {
+          "name": "distance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hcp": {
+          "name": "hcp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hole_teeId_fkey": {
+          "name": "hole_teeId_fkey",
+          "tableFrom": "hole",
+          "tableTo": "teeInfo",
+          "columnsFrom": [
+            "teeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view holes": {
+          "name": "Authenticated users can view holes",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile": {
+      "name": "profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "handicapIndex": {
+          "name": "handicapIndex",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 54
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initialHandicapIndex": {
+          "name": "initialHandicapIndex",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 54
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "profile_email_key": {
+          "name": "profile_email_key",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "text_ops"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "profile_id_fkey": {
+          "name": "profile_id_fkey",
+          "tableFrom": "profile",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own profile": {
+          "name": "Users can view their own profile",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(auth.uid()::uuid = id)"
+        },
+        "Users can update their own profile": {
+          "name": "Users can update their own profile",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(auth.uid()::uuid = id)"
+        },
+        "Users can insert their own profile": {
+          "name": "Users can insert their own profile",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(auth.uid()::uuid = id)"
+        },
+        "Users can delete their own profile": {
+          "name": "Users can delete their own profile",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(auth.uid()::uuid = id)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.round": {
+      "name": "round",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "courseId": {
+          "name": "courseId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teeId": {
+          "name": "teeId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "teeTime": {
+          "name": "teeTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalStrokes": {
+          "name": "totalStrokes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parPlayed": {
+          "name": "parPlayed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adjustedGrossScore": {
+          "name": "adjustedGrossScore",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adjustedPlayedScore": {
+          "name": "adjustedPlayedScore",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "courseHandicap": {
+          "name": "courseHandicap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scoreDifferential": {
+          "name": "scoreDifferential",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "existingHandicapIndex": {
+          "name": "existingHandicapIndex",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedHandicapIndex": {
+          "name": "updatedHandicapIndex",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exceptionalScoreAdjustment": {
+          "name": "exceptionalScoreAdjustment",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "approvalStatus": {
+          "name": "approvalStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "round_courseId_fkey": {
+          "name": "round_courseId_fkey",
+          "tableFrom": "round",
+          "tableTo": "course",
+          "columnsFrom": [
+            "courseId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "round_userId_fkey": {
+          "name": "round_userId_fkey",
+          "tableFrom": "round",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "round_teeId_fkey": {
+          "name": "round_teeId_fkey",
+          "tableFrom": "round",
+          "tableTo": "teeInfo",
+          "columnsFrom": [
+            "teeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own rounds": {
+          "name": "Users can view their own rounds",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(auth.uid()::uuid = userId)"
+        },
+        "Users can insert their own rounds": {
+          "name": "Users can insert their own rounds",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(auth.uid()::uuid = userId)"
+        },
+        "Users can update their own rounds": {
+          "name": "Users can update their own rounds",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(auth.uid()::uuid = userId)"
+        },
+        "Users can delete their own rounds": {
+          "name": "Users can delete their own rounds",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(auth.uid()::uuid = userId)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.score": {
+      "name": "score",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roundId": {
+          "name": "roundId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "holeId": {
+          "name": "holeId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strokes": {
+          "name": "strokes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hcpStrokes": {
+          "name": "hcpStrokes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "score_roundId_fkey": {
+          "name": "score_roundId_fkey",
+          "tableFrom": "score",
+          "tableTo": "round",
+          "columnsFrom": [
+            "roundId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        },
+        "score_holeId_fkey": {
+          "name": "score_holeId_fkey",
+          "tableFrom": "score",
+          "tableTo": "hole",
+          "columnsFrom": [
+            "holeId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "cascade"
+        },
+        "score_userId_fkey": {
+          "name": "score_userId_fkey",
+          "tableFrom": "score",
+          "tableTo": "profile",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Users can view their own scores": {
+          "name": "Users can view their own scores",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(auth.uid()::uuid = userId)"
+        },
+        "Users can insert their own scores": {
+          "name": "Users can insert their own scores",
+          "as": "PERMISSIVE",
+          "for": "INSERT",
+          "to": [
+            "authenticated"
+          ],
+          "withCheck": "(auth.uid()::uuid = userId)"
+        },
+        "Users can update their own scores": {
+          "name": "Users can update their own scores",
+          "as": "PERMISSIVE",
+          "for": "UPDATE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(auth.uid()::uuid = userId)"
+        },
+        "Users can delete their own scores": {
+          "name": "Users can delete their own scores",
+          "as": "PERMISSIVE",
+          "for": "DELETE",
+          "to": [
+            "authenticated"
+          ],
+          "using": "(auth.uid()::uuid = userId)"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.teeInfo": {
+      "name": "teeInfo",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "courseId": {
+          "name": "courseId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "courseRating18": {
+          "name": "courseRating18",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slopeRating18": {
+          "name": "slopeRating18",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "courseRatingFront9": {
+          "name": "courseRatingFront9",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slopeRatingFront9": {
+          "name": "slopeRatingFront9",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "courseRatingBack9": {
+          "name": "courseRatingBack9",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slopeRatingBack9": {
+          "name": "slopeRatingBack9",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outPar": {
+          "name": "outPar",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inPar": {
+          "name": "inPar",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalPar": {
+          "name": "totalPar",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outDistance": {
+          "name": "outDistance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inDistance": {
+          "name": "inDistance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalDistance": {
+          "name": "totalDistance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distanceMeasurement": {
+          "name": "distanceMeasurement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'yards'"
+        },
+        "approvalStatus": {
+          "name": "approvalStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "isArchived": {
+          "name": "isArchived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teeInfo_courseId_fkey": {
+          "name": "teeInfo_courseId_fkey",
+          "tableFrom": "teeInfo",
+          "tableTo": "course",
+          "columnsFrom": [
+            "courseId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {
+        "Authenticated users can view tee info": {
+          "name": "Authenticated users can view tee info",
+          "as": "PERMISSIVE",
+          "for": "SELECT",
+          "to": [
+            "authenticated"
+          ],
+          "using": "true"
+        }
+      },
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "auth.users": {
+      "name": "users",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/supabase/migrations/meta/_journal.json
+++ b/supabase/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1755032947018,
       "tag": "20250812210907_hard_stone_men",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1755623157381,
+      "tag": "20250819170557_futuristic_terrax",
+      "breakpoints": true
     }
   ]
 }

--- a/types/scorecard.ts
+++ b/types/scorecard.ts
@@ -184,6 +184,8 @@ export const courseSchema = z.object({
   id: z.number().or(z.undefined()),
   name: z.string(),
   approvalStatus: z.literal("pending").or(z.literal("approved")),
+  country: z.string(),
+  website: z.string().optional(),
   tees: z
     .array(teeSchema)
     .min(1, "At least one tee required")
@@ -202,6 +204,8 @@ export const courseCreationSchema = courseSchema.extend({
       100,
       "Course name must be less than 100 characters. Contact us if you need to add a course out of this range."
     ),
+  country: z.string(),
+  website: z.string().optional(),
   tees: z.array(teeCreationSchema).min(1, "At least one tee required"),
 });
 

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -7,7 +7,7 @@ export type Json =
   | Json[]
 
 export type Database = {
-  // Allows to automatically instanciate createClient with right options
+  // Allows to automatically instantiate createClient with right options
   // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
     PostgrestVersion: "12.2.3 (519615d)"
@@ -304,6 +304,42 @@ export type Database = {
             referencedColumns: ["id"]
           },
         ]
+      }
+      trigger_debug_log: {
+        Row: {
+          approval_status: string | null
+          created_at: string | null
+          http_post_result: Json | null
+          id: number
+          op: string
+          payload: Json | null
+          round_id: number | null
+          service_role_key_prefix: string | null
+          user_id: string | null
+        }
+        Insert: {
+          approval_status?: string | null
+          created_at?: string | null
+          http_post_result?: Json | null
+          id?: number
+          op: string
+          payload?: Json | null
+          round_id?: number | null
+          service_role_key_prefix?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          approval_status?: string | null
+          created_at?: string | null
+          http_post_result?: Json | null
+          id?: number
+          op?: string
+          payload?: Json | null
+          round_id?: number | null
+          service_role_key_prefix?: string | null
+          user_id?: string | null
+        }
+        Relationships: []
       }
     }
     Views: {

--- a/utils/calculations/handicap.ts
+++ b/utils/calculations/handicap.ts
@@ -1,4 +1,3 @@
-import { RoundWithCourseAndTee } from "@/types/database";
 import { Hole, Score, Tee } from "@/types/scorecard";
 import { Tables } from "@/types/supabase";
 import { SupabaseClient } from "@supabase/supabase-js";
@@ -42,7 +41,7 @@ export function calculateCourseHandicap(
 export function calculateScoreDifferential(
   adjustedGrossScore: number,
   courseRating: number,
-  slopeRating: number,
+  slopeRating: number
 ): number {
   const scoreDiff = (adjustedGrossScore - courseRating) * (113 / slopeRating);
   // If scoreDiff is negative, round upwards towards 0 (to 1 decimal)
@@ -302,24 +301,24 @@ function applyHandicapAdjustement(
 }
 
 /**
- * 
- * @param holes 
- * @param roundScores 
- * @param courseHandicap 
- * @param numberOfHolesPlayed 
- * @returns 
+ *
+ * @param holes
+ * @param roundScores
+ * @param courseHandicap
+ * @param numberOfHolesPlayed
+ * @returns
  */
 export function addHcpStrokesToScores(
   holes: Hole[],
   roundScores: Score[],
   courseHandicap: number,
-  numberOfHolesPlayed: number,
+  numberOfHolesPlayed: number
 ): Score[] {
   const fullDivision = Math.floor(courseHandicap / numberOfHolesPlayed);
   const remainder = courseHandicap % numberOfHolesPlayed;
 
-  console.log(holes)
-  console.log(roundScores)
+  console.log(holes);
+  console.log(roundScores);
 
   // Get only the holes that were played, in the order of roundScores
   holes.forEach((hole, index) => {

--- a/utils/scorecard/tee.ts
+++ b/utils/scorecard/tee.ts
@@ -134,6 +134,7 @@ export const validCourse: Course = {
   name: "Ballerud",
   approvalStatus: "pending",
   id: -1,
+  country: "Norway",
   tees: [
     {
       id: -1,
@@ -301,5 +302,6 @@ export const blankCourse: Course = {
   name: "",
   approvalStatus: "pending",
   id: -1,
+  country: "Norway",
   tees: [blankTee],
 };


### PR DESCRIPTION
## What was done

- Added country and website (optional) field to course table
- Updated db queries which interact with the course table to include the updated data
- Added country input to add course dialog
- Created component for country selection

## How to test

- Visit localhost:3000/rounds/add 
- Open the add course dialog
- In country selection, search for a country
- Submit scorecard
- See the data appear in the local db

## Future work
- Update course fetching names to include country
- Add website input field to add course dialog