### PR TITLE
🐛 fix: landing page default marketing values

### DIFF
--- a/components/homepage/landing.tsx
+++ b/components/homepage/landing.tsx
@@ -201,9 +201,9 @@ export default async function Landing() {
           <div className="grid md:grid-cols-3 gap-8 text-center">
             <div>
               <div className="text-4xl font-bold text-primary mb-2">
-                {numberOfUsers}+
+                {numberOfUsers > 0 ? numberOfUsers : "10"}+
               </div>
-              <div className="text-muted-foreground">Active Golfers</div>
+              <div className="text-muted-foreground">Active Users</div>
             </div>
             <div>
               <div className="text-4xl font-bold text-primary mb-2">


### PR DESCRIPTION
## What was done

- Added default marketing values to the landing page when no data exists

## How to test

- Go to localhost:3000
- See that there are "10+" users

## Future work
- None