### PR TITLE
Cross-platform billing: Apple IAP (RevenueCat) + Stripe into one entitlement projection

### DIFF
--- a/apps/native/.maestro/billing-states/state-apple-active.yaml
+++ b/apps/native/.maestro/billing-states/state-apple-active.yaml
@@ -1,0 +1,41 @@
+# BILLING STATE: apple + unlimited + active (§1 "active + provider apple →
+# native plan change + Apple manage link"). Driven by a REAL
+# INITIAL_PURCHASE webhook against the local server.
+appId: com.handicappin.app
+---
+- stopApp
+- openLink: handicappin://
+- tapOn:
+    text: "Open"
+    optional: true
+- extendedWaitUntil:
+    visible:
+      id: "tab-profile"
+    timeout: 30000
+- tapOn:
+    id: "tab-profile"
+- extendedWaitUntil:
+    visible: "Manage your account settings"
+    timeout: 20000
+- tapOn:
+    id: "profile-tab-billing"
+- extendedWaitUntil:
+    visible: ".*[Uu]nlimited Plan.*"
+    timeout: 15000
+- assertVisible: ".*Renews on.*"
+# Native plan change within the subscription group + Apple manage link.
+- assertVisible:
+    id: "billing-plan-change"
+- assertVisible: "Switch to Premium"
+- assertVisible:
+    id: "billing-apple-manage"
+- assertVisible: "Manage Subscription (App Store)"
+# No purchase buttons, no stripe neutral copy.
+- assertNotVisible: "Upgrade Your Plan"
+- assertNotVisible: ".*managed on handicappin.com.*"
+- scrollUntilVisible:
+    element:
+      id: "billing-restore"
+    centerElement: true
+- assertVisible: "Restore Purchases"
+- takeScreenshot: /tmp/handicappin-billing-states/apple-unlimited-active

--- a/apps/native/.maestro/billing-states/state-apple-cap.yaml
+++ b/apps/native/.maestro/billing-states/state-apple-cap.yaml
@@ -1,0 +1,36 @@
+# BILLING STATE: apple + unlimited + active + cancel_at_period_end (driven
+# by a REAL CANCELLATION webhook). Still active until period end: plan
+# change + manage remain; the status line says "Cancels on ...".
+appId: com.handicappin.app
+---
+- stopApp
+- openLink: handicappin://
+- tapOn:
+    text: "Open"
+    optional: true
+- extendedWaitUntil:
+    visible:
+      id: "tab-profile"
+    timeout: 30000
+- tapOn:
+    id: "tab-profile"
+- extendedWaitUntil:
+    visible: "Manage your account settings"
+    timeout: 20000
+- tapOn:
+    id: "profile-tab-billing"
+- extendedWaitUntil:
+    visible: ".*[Uu]nlimited Plan.*"
+    timeout: 15000
+- assertVisible: ".*Cancels on.*"
+- assertVisible:
+    id: "billing-plan-change"
+- assertVisible:
+    id: "billing-apple-manage"
+- assertNotVisible: "Upgrade Your Plan"
+- scrollUntilVisible:
+    element:
+      id: "billing-restore"
+    centerElement: true
+- assertVisible: "Restore Purchases"
+- takeScreenshot: /tmp/handicappin-billing-states/apple-cancel-at-period-end

--- a/apps/native/.maestro/billing-states/state-free.yaml
+++ b/apps/native/.maestro/billing-states/state-free.yaml
@@ -1,0 +1,60 @@
+# BILLING STATE: plan=free (§1 matrix row "plan null/free → full paywall").
+# PRE-REQUISITE: signed in as the test user; profile driven to free via SQL.
+# Expects: purchasable paywall (real lineup), restore, disclosure; no
+# stripe neutral copy, no apple manage.
+appId: com.handicappin.app
+---
+- stopApp
+- openLink: handicappin://
+- tapOn:
+    text: "Open"
+    optional: true
+- extendedWaitUntil:
+    visible:
+      id: "tab-profile"
+    timeout: 30000
+- tapOn:
+    id: "tab-profile"
+- extendedWaitUntil:
+    visible: "Manage your account settings"
+    timeout: 20000
+- tapOn:
+    id: "profile-tab-billing"
+- extendedWaitUntil:
+    visible: ".*[Ff]ree Plan.*"
+    timeout: 15000
+- assertVisible: ".*rounds remaining.*"
+# Full paywall: the real lineup is purchasable.
+- scrollUntilVisible:
+    element:
+      text: "Upgrade Your Plan"
+    centerElement: true
+- assertVisible: "Upgrade Your Plan"
+- takeScreenshot: /tmp/handicappin-billing-states/free-paywall
+- scrollUntilVisible:
+    element:
+      id: "paywall-buy-unlimited_yearly"
+    centerElement: true
+- assertVisible:
+    id: "paywall-buy-premium_yearly"
+- assertVisible:
+    id: "paywall-buy-unlimited_yearly"
+# Purchase through the seam surfaces the labelled dev notice (mock mode).
+- tapOn:
+    id: "paywall-buy-premium_yearly"
+- extendedWaitUntil:
+    visible: ".*development build.*"
+    timeout: 8000
+- takeScreenshot: /tmp/handicappin-billing-states/free-mock-notice
+# Disclosure + restore always visible.
+- scrollUntilVisible:
+    element:
+      id: "paywall-disclosure"
+- assertVisible: ".*renew automatically.*"
+- scrollUntilVisible:
+    element:
+      id: "billing-restore"
+    direction: UP
+- assertVisible: "Restore Purchases"
+- assertNotVisible: ".*managed on handicappin.com.*"
+- takeScreenshot: /tmp/handicappin-billing-states/free-restore

--- a/apps/native/.maestro/billing-states/state-lifetime.yaml
+++ b/apps/native/.maestro/billing-states/state-lifetime.yaml
@@ -1,0 +1,39 @@
+# BILLING STATE: lifetime (§1 "lifetime (any provider) → no purchase
+# buttons"). Driven by a REAL NON_RENEWING_PURCHASE webhook (apple lifetime).
+appId: com.handicappin.app
+---
+- stopApp
+- openLink: handicappin://
+- tapOn:
+    text: "Open"
+    optional: true
+- extendedWaitUntil:
+    visible:
+      id: "tab-profile"
+    timeout: 30000
+- tapOn:
+    id: "tab-profile"
+- extendedWaitUntil:
+    visible: "Manage your account settings"
+    timeout: 20000
+- tapOn:
+    id: "profile-tab-billing"
+- extendedWaitUntil:
+    visible: ".*[Ll]ifetime Plan.*"
+    timeout: 15000
+- assertVisible: ".*Lifetime Access.*"
+- assertVisible: "No subscription management needed"
+# No purchase, no plan change, no manage, no neutral copy.
+- assertNotVisible: "Upgrade Your Plan"
+- assertNotVisible:
+    id: "billing-plan-change"
+- assertNotVisible:
+    id: "billing-apple-manage"
+- assertNotVisible: ".*managed on handicappin.com.*"
+# Restore always visible.
+- scrollUntilVisible:
+    element:
+      id: "billing-restore"
+    centerElement: true
+- assertVisible: "Restore Purchases"
+- takeScreenshot: /tmp/handicappin-billing-states/lifetime

--- a/apps/native/.maestro/billing-states/state-null-onboarding.yaml
+++ b/apps/native/.maestro/billing-states/state-null-onboarding.yaml
@@ -1,0 +1,42 @@
+# BILLING STATE: plan=NULL (§1 "plan null/free → full paywall").
+# PRE-REQUISITE: signed in as the test user with plan_selected=NULL — the
+# claims route plan-less users to onboarding. Extends onboarding.yaml's
+# assertions with the policy items: restore always visible + disclosure.
+appId: com.handicappin.app
+---
+- stopApp
+- openLink: handicappin://onboarding
+- tapOn:
+    text: "Open"
+    optional: true
+- assertVisible: "Welcome to Handicappin!"
+- assertVisible: "Free"
+- assertVisible: "Start Free"
+- takeScreenshot: /tmp/handicappin-billing-states/null-onboarding-top
+# Paid CTA goes through the billing seam → labelled dev notice (mock mode).
+- scrollUntilVisible:
+    element:
+      id: "plan-premium-cta"
+    centerElement: true
+- tapOn:
+    id: "plan-premium-cta"
+# The feedback banner renders at the top of the scroll view.
+- scrollUntilVisible:
+    element:
+      text: ".*development build.*"
+    direction: UP
+    timeout: 20000
+- takeScreenshot: /tmp/handicappin-billing-states/null-onboarding-mock-notice
+# §1: Restore always visible; 3.1.2 disclosure + legal links present.
+- scrollUntilVisible:
+    element:
+      id: "onboarding-restore"
+    timeout: 60000
+- assertVisible: "Restore Purchases"
+- scrollUntilVisible:
+    element:
+      text: ".*renew automatically.*"
+    timeout: 30000
+- assertVisible: "Terms of Service"
+- assertVisible: "Privacy Policy"
+- takeScreenshot: /tmp/handicappin-billing-states/null-onboarding-disclosure

--- a/apps/native/.maestro/billing-states/state-past-due.yaml
+++ b/apps/native/.maestro/billing-states/state-past-due.yaml
@@ -1,0 +1,38 @@
+# BILLING STATE: apple + unlimited + past_due (driven by a REAL
+# BILLING_ISSUE webhook → D-status-mapping: past_due, access denied).
+# Policy (D26): payment-issue line; manage affordance to fix payment; NO
+# plan change, NO purchase buttons; restore stays.
+appId: com.handicappin.app
+---
+- stopApp
+- openLink: handicappin://
+- tapOn:
+    text: "Open"
+    optional: true
+- extendedWaitUntil:
+    visible:
+      id: "tab-profile"
+    timeout: 30000
+- tapOn:
+    id: "tab-profile"
+- extendedWaitUntil:
+    visible: "Manage your account settings"
+    timeout: 20000
+- tapOn:
+    id: "profile-tab-billing"
+- extendedWaitUntil:
+    visible: ".*[Uu]nlimited Plan.*"
+    timeout: 15000
+- assertVisible: ".*Payment issue.*"
+- assertVisible:
+    id: "billing-apple-manage"
+- assertNotVisible:
+    id: "billing-plan-change"
+- assertNotVisible: "Upgrade Your Plan"
+- assertNotVisible: ".*managed on handicappin.com.*"
+- scrollUntilVisible:
+    element:
+      id: "billing-restore"
+    centerElement: true
+- assertVisible: "Restore Purchases"
+- takeScreenshot: /tmp/handicappin-billing-states/apple-past-due

--- a/apps/native/.maestro/billing-states/state-stripe-active.yaml
+++ b/apps/native/.maestro/billing-states/state-stripe-active.yaml
@@ -1,0 +1,41 @@
+# BILLING STATE: stripe + premium + active (§1 "active + provider stripe →
+# no purchase buttons; neutral copy" — and per D-policy, NO tappable link).
+# PRE-REQUISITE: signed in; profile driven to stripe/premium/active.
+appId: com.handicappin.app
+---
+- stopApp
+- openLink: handicappin://
+- tapOn:
+    text: "Open"
+    optional: true
+- extendedWaitUntil:
+    visible:
+      id: "tab-profile"
+    timeout: 30000
+- tapOn:
+    id: "tab-profile"
+- extendedWaitUntil:
+    visible: "Manage your account settings"
+    timeout: 20000
+- tapOn:
+    id: "profile-tab-billing"
+- extendedWaitUntil:
+    visible: ".*[Pp]remium Plan.*"
+    timeout: 15000
+- assertVisible: ".*Renews on.*"
+# Neutral copy present; no purchase/plan-change/manage affordances.
+- assertVisible:
+    id: "billing-stripe-neutral"
+- assertVisible: ".*managed on handicappin.com.*"
+- assertNotVisible: "Upgrade Your Plan"
+- assertNotVisible:
+    id: "billing-plan-change"
+- assertNotVisible:
+    id: "billing-apple-manage"
+# Restore always visible.
+- scrollUntilVisible:
+    element:
+      id: "billing-restore"
+    centerElement: true
+- assertVisible: "Restore Purchases"
+- takeScreenshot: /tmp/handicappin-billing-states/stripe-premium-active

--- a/apps/native/.maestro/utils/sign-in.yaml
+++ b/apps/native/.maestro/utils/sign-in.yaml
@@ -1,0 +1,22 @@
+# UTIL · sign in as the local test user (local-only creds, see the native
+# handoff §7; mirror of auth-roundtrip's second half). Lands wherever the
+# claims route the account (home for plan-holders, onboarding for plan-less).
+appId: com.handicappin.app
+---
+- stopApp
+- openLink: handicappin://login
+- tapOn:
+    text: "Open"
+    optional: true
+- extendedWaitUntil:
+    visible: "Welcome Back"
+    timeout: 20000
+- tapOn:
+    id: "login-email"
+- inputText: "native-goal-test@handicappin.local"
+- tapOn:
+    id: "login-password"
+- inputText: "NativeGoal2026!"
+- pressKey: Enter
+- tapOn:
+    id: "login-submit"

--- a/apps/native/.maestro/utils/sign-out.yaml
+++ b/apps/native/.maestro/utils/sign-out.yaml
@@ -1,0 +1,34 @@
+# UTIL · sign out via Profile → Settings (drives the signed-out state the
+# login/forgot-password flows require; mirror of auth-roundtrip's first half).
+appId: com.handicappin.app
+---
+- stopApp
+- openLink: handicappin://
+- tapOn:
+    text: "Open"
+    optional: true
+- extendedWaitUntil:
+    visible:
+      id: "tab-profile"
+    timeout: 30000
+- tapOn:
+    id: "tab-profile"
+- extendedWaitUntil:
+    visible: "Manage your account settings"
+    timeout: 20000
+- scrollUntilVisible:
+    element:
+      id: "profile-tab-settings"
+    direction: UP
+    centerElement: true
+- tapOn:
+    id: "profile-tab-settings"
+- scrollUntilVisible:
+    element:
+      id: "sign-out"
+    centerElement: true
+- tapOn:
+    id: "sign-out"
+- extendedWaitUntil:
+    visible: "Welcome Back"
+    timeout: 20000

--- a/apps/native/app.config.ts
+++ b/apps/native/app.config.ts
@@ -28,6 +28,9 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       supabaseAnonKey:
         process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? LOCAL_SUPABASE_ANON_KEY,
       apiBaseUrl: process.env.EXPO_PUBLIC_API_BASE_URL ?? LOCAL_API_BASE_URL,
+      // Billing seam switch (D-seam): unset → RevenueCat-shaped mock.
+      revenueCatIosApiKey:
+        process.env.EXPO_PUBLIC_REVENUECAT_IOS_API_KEY ?? null,
     },
   },
 });

--- a/apps/native/app.config.ts
+++ b/apps/native/app.config.ts
@@ -28,9 +28,15 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       supabaseAnonKey:
         process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? LOCAL_SUPABASE_ANON_KEY,
       apiBaseUrl: process.env.EXPO_PUBLIC_API_BASE_URL ?? LOCAL_API_BASE_URL,
-      // Billing seam switch (D-seam): unset → RevenueCat-shaped mock.
-      revenueCatIosApiKey:
-        process.env.EXPO_PUBLIC_REVENUECAT_IOS_API_KEY ?? null,
+      // Billing seam switch (D-seam): unset → RevenueCat-shaped mock. The
+      // key is OMITTED (not null) when unset — Expo's manifest serializer
+      // mangles null extra values into {}.
+      ...(process.env.EXPO_PUBLIC_REVENUECAT_IOS_API_KEY
+        ? {
+            revenueCatIosApiKey:
+              process.env.EXPO_PUBLIC_REVENUECAT_IOS_API_KEY,
+          }
+        : {}),
     },
   },
 });

--- a/apps/native/app.json
+++ b/apps/native/app.json
@@ -24,7 +24,8 @@
         "backgroundImage": "./assets/images/android-icon-background.png",
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
-      "predictiveBackGestureEnabled": false
+      "predictiveBackGestureEnabled": false,
+      "package": "com.handicappin.app"
     },
     "web": {
       "bundler": "metro",

--- a/apps/native/app/(tabs)/profile/[id].tsx
+++ b/apps/native/app/(tabs)/profile/[id].tsx
@@ -32,12 +32,29 @@ import { FormFeedback } from "@/components/ui/form-feedback";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { H1, H2, H3 } from "@/components/ui/typography";
+import type { PaidPlan } from "@handicappin/billing-core";
+
+import { PaywallPackages } from "@/components/billing/paywall-packages";
 import { trpcMutation } from "@/lib/api/client";
 import { profileQueryOptions } from "@/lib/api/procedures/auth";
 import { roundCountQueryOptions } from "@/lib/api/procedures/round";
+import type {
+  BillingProviderId,
+  PlanType,
+  SubscriptionStatus,
+} from "@/lib/api/schemas/profile";
 import { useSession } from "@/lib/auth/session-provider";
-import { billing } from "@/lib/billing";
 import { PLAN_FEATURES } from "@/lib/billing/plan-content";
+import {
+  paywallPolicyFor,
+  STRIPE_NEUTRAL_COPY,
+} from "@/lib/billing/paywall-policy";
+import {
+  getManagementUrl,
+  MOCK_RESTORE_PREFIX,
+  purchasePlan,
+  restorePurchases,
+} from "@/lib/billing/purchase-flow";
 import { useColorMode } from "@/lib/color-mode";
 import { openLegalDocument, SITE_URL } from "@/lib/legal";
 import { useDataSettled } from "@/lib/query/settle";
@@ -179,13 +196,15 @@ export default function ProfileScreen() {
           {tab === "billing" ? (
             <BillingTab
               plan={profile.plan_selected}
+              status={profile.subscription_status}
+              provider={profile.billing_provider}
               currentPeriodEnd={profile.current_period_end}
               cancelAtPeriodEnd={profile.cancel_at_period_end}
               roundCount={roundCountQuery.data ?? 0}
               userId={profile.id}
             />
           ) : null}
-          {tab === "settings" ? <SettingsTab /> : null}
+          {tab === "settings" ? <SettingsTab userId={profile.id} /> : null}
         </>
       )}
     </ScrollView>
@@ -290,33 +309,94 @@ function PersonalTab({
 
 function BillingTab({
   plan,
+  status,
+  provider,
   currentPeriodEnd,
   cancelAtPeriodEnd,
   roundCount,
   userId,
 }: {
-  plan: string | null;
+  plan: PlanType | null;
+  status: SubscriptionStatus | null;
+  provider: BillingProviderId | null;
   currentPeriodEnd: number | null;
   cancelAtPeriodEnd: boolean;
   roundCount: number;
   userId: string;
 }) {
   const [feedback, setFeedback] = useState<FeedbackState | null>(null);
+  const [changingPlan, setChangingPlan] = useState(false);
+  const queryClient = useQueryClient();
   const isLifetime = plan === "lifetime";
   const remainingRounds = Math.max(0, FREE_TIER_ROUND_LIMIT - roundCount);
   const features = PLAN_FEATURES[plan ?? "free"] ?? [];
 
+  // THE §1 policy matrix — drives every affordance below.
+  const policy = paywallPolicyFor({ plan, status, provider, cancelAtPeriodEnd });
+  const refreshProfile = () =>
+    void queryClient.invalidateQueries({
+      queryKey: ["auth.getProfileFromUserId", userId],
+    });
+
   const onRestore = async () => {
-    // Decision ledger: restore is a MOCKED flow — re-reads the REAL backend
-    // state through the RevenueCat-shaped seam and says so out loud.
-    await billing.configure({ appUserID: userId });
-    const info = await billing.restorePurchases();
-    const active = Object.keys(info.entitlements.active);
+    const result = await restorePurchases(userId);
+    if (result.kind === "error") {
+      setFeedback({ type: "error", message: result.message });
+      return;
+    }
+    const list =
+      result.activeEntitlements.length > 0
+        ? result.activeEntitlements.join(", ")
+        : "none";
     setFeedback({
       type: "info",
-      message: `Dev build: purchases are mocked. Backend state restored — active entitlement${active.length === 1 ? "" : "s"}: ${active.length > 0 ? active.join(", ") : "none"}.`,
+      message: result.mocked
+        ? `${MOCK_RESTORE_PREFIX} Backend state restored — active entitlement${result.activeEntitlements.length === 1 ? "" : "s"}: ${list}.`
+        : `Purchases restored — active entitlement${result.activeEntitlements.length === 1 ? "" : "s"}: ${list}.`,
     });
+    if (!result.mocked) refreshProfile();
   };
+
+  // Apple-billed plan change: the OTHER yearly tier, same subscription group.
+  const planChangeTarget: PaidPlan | null =
+    plan === "premium" ? "unlimited" : plan === "unlimited" ? "premium" : null;
+
+  const onPlanChange = async (target: PaidPlan) => {
+    setChangingPlan(true);
+    try {
+      const result = await purchasePlan(userId, target);
+      if (result.kind === "mock-notice") {
+        setFeedback({ type: "info", message: result.message });
+      } else if (result.kind === "purchased") {
+        setFeedback({
+          type: "success",
+          message: `Plan change complete — you're now on ${target}.`,
+        });
+        refreshProfile();
+      } else if (result.kind === "error") {
+        setFeedback({ type: "error", message: result.message });
+      }
+    } finally {
+      setChangingPlan(false);
+    }
+  };
+
+  const onAppleManage = async () => {
+    const url = await getManagementUrl(userId);
+    void WebBrowser.openBrowserAsync(url);
+  };
+
+  const statusLine = (() => {
+    if (status === "past_due") {
+      return "Payment issue — please update your payment method.";
+    }
+    if (currentPeriodEnd && !isLifetime) {
+      return cancelAtPeriodEnd
+        ? `Cancels on ${formatDate(currentPeriodEnd)}`
+        : `Renews on ${formatDate(currentPeriodEnd)}`;
+    }
+    return null;
+  })();
 
   return (
     <View className="gap-lg" testID="profile-billing">
@@ -346,11 +426,16 @@ function BillingTab({
               {remainingRounds} rounds remaining
             </Text>
           ) : null}
-          {currentPeriodEnd && !isLifetime ? (
-            <Text className="text-body text-muted-foreground">
-              {cancelAtPeriodEnd
-                ? `Cancels on ${formatDate(currentPeriodEnd)}`
-                : `Renews on ${formatDate(currentPeriodEnd)}`}
+          {statusLine ? (
+            <Text
+              className={cn(
+                "text-body",
+                status === "past_due"
+                  ? "text-destructive"
+                  : "text-muted-foreground",
+              )}
+            >
+              {statusLine}
             </Text>
           ) : null}
           {isLifetime ? (
@@ -359,25 +444,63 @@ function BillingTab({
             </Text>
           ) : null}
         </View>
+
         <View className="gap-sm">
-          {!isLifetime ? (
-            <Button
-              onPress={() => {
-                void WebBrowser.openBrowserAsync(`${SITE_URL}/upgrade`);
-              }}
+          {/* §1: stripe-sourced — neutral copy, deliberately NOT a link */}
+          {policy.showStripeNeutralCopy ? (
+            <Text
+              testID="billing-stripe-neutral"
+              className="text-body-sm text-muted-foreground"
             >
-              {plan === "free" ? "Upgrade Plan" : "Change Plan"}
+              {STRIPE_NEUTRAL_COPY}
+            </Text>
+          ) : null}
+
+          {/* §1: apple-sourced — native plan change within the group */}
+          {policy.showNativePlanChange && planChangeTarget ? (
+            <Button
+              testID="billing-plan-change"
+              disabled={changingPlan}
+              onPress={() => void onPlanChange(planChangeTarget)}
+            >
+              {changingPlan
+                ? "Working…"
+                : `Switch to ${planChangeTarget === "unlimited" ? "Unlimited" : "Premium"}`}
             </Button>
-          ) : (
+          ) : null}
+
+          {/* §1: apple-sourced — Apple manage-subscriptions affordance */}
+          {policy.showAppleManage ? (
+            <Button
+              testID="billing-apple-manage"
+              variant="outline"
+              onPress={() => void onAppleManage()}
+            >
+              Manage Subscription (App Store)
+            </Button>
+          ) : null}
+
+          {isLifetime ? (
             <Text className="text-body-sm text-muted-foreground">
               No subscription management needed
             </Text>
-          )}
-          <Button variant="outline" onPress={() => void onRestore()}>
+          ) : null}
+
+          {/* §1: Restore always visible */}
+          <Button
+            testID="billing-restore"
+            variant="outline"
+            onPress={() => void onRestore()}
+          >
             Restore Purchases
           </Button>
         </View>
       </View>
+
+      {/* §1: plan null/free — full paywall (purchasable) */}
+      {policy.showPurchaseButtons ? (
+        <PaywallPackages userId={userId} onPurchased={refreshProfile} />
+      ) : null}
 
       <View className="surface p-lg rounded-lg gap-md">
         <H3>Plan Features</H3>
@@ -410,13 +533,20 @@ function BillingTab({
   );
 }
 
-function SettingsTab() {
+function SettingsTab({ userId }: { userId: string }) {
   const mode = useColorMode();
   const colors = tokens.colors[mode];
 
   const onSignOut = async () => {
     await supabase.auth.signOut();
     router.replace("/login");
+  };
+
+  // App Store 5.1.1(v): account deletion must be reachable in-app. Web's
+  // REAL deletion flow (OTP-confirmed, cancels subscriptions, deletes auth
+  // user + data) lives on the profile page's settings tab — link out to it.
+  const onDeleteAccount = () => {
+    void WebBrowser.openBrowserAsync(`${SITE_URL}/profile/${userId}`);
   };
 
   return (
@@ -454,8 +584,25 @@ function SettingsTab() {
           </View>
         </Button>
         <Text className="text-meta text-muted-foreground">
-          Data export and account deletion are available on handicappin.com.
+          Data export is available on handicappin.com.
         </Text>
+      </View>
+
+      <View className="surface p-lg rounded-lg gap-md">
+        <H3>Account</H3>
+        <Text className="text-body-sm text-muted-foreground">
+          Deleting your account permanently removes your profile, rounds, and
+          statistics, and cancels any active subscription. Deletion is
+          completed on handicappin.com (your profile page → Settings) with
+          email confirmation.
+        </Text>
+        <Button
+          testID="settings-delete-account"
+          variant="outline"
+          onPress={onDeleteAccount}
+        >
+          <Text className="text-label-sm text-destructive">Delete Account</Text>
+        </Button>
       </View>
 
       <View className="surface p-lg rounded-lg gap-md">

--- a/apps/native/app/(tabs)/profile/[id].tsx
+++ b/apps/native/app/(tabs)/profile/[id].tsx
@@ -238,7 +238,7 @@ function PersonalTab({
     onSuccess: () => {
       setFeedback({ type: "success", message: "Profile updated" });
       void queryClient.invalidateQueries({
-        queryKey: ["auth.getProfileFromUserId", profileId],
+        queryKey: profileQueryOptions(profileId).queryKey,
       });
     },
     onError: (error) => {
@@ -335,7 +335,7 @@ function BillingTab({
   const policy = paywallPolicyFor({ plan, status, provider, cancelAtPeriodEnd });
   const refreshProfile = () =>
     void queryClient.invalidateQueries({
-      queryKey: ["auth.getProfileFromUserId", userId],
+      queryKey: profileQueryOptions(userId).queryKey,
     });
 
   const onRestore = async () => {

--- a/apps/native/app/onboarding.tsx
+++ b/apps/native/app/onboarding.tsx
@@ -1,11 +1,13 @@
 /**
  * Onboarding — native twin of apps/web/app/onboarding/page.tsx (plan
- * selection). Promo slots come from the REAL stripe.getPromoSlots tRPC
- * query; plan SELECTION routes through the billing mock seam (decision
- * ledger §1: purchase flows are mocked with a clearly-labelled dev notice;
- * the web flow remains the way to actually purchase until RevenueCat).
- * Web redirects plan-holders to /billing (web-only route) — native sends
- * them home instead (logged decision D10).
+ * selection): the FULL PAYWALL row of the §1 policy matrix (plan null →
+ * purchasable). Promo slots come from the REAL stripe.getPromoSlots tRPC
+ * query; paid-plan CTAs purchase through the billing seam (mock → labelled
+ * dev notice; real RevenueCat SDK → App Store sheet, D-seam). Free-plan
+ * selection and the EARLY100 promo claim are web server flows — they keep
+ * the dev notice pointing at handicappin.com (D10). Restore is always
+ * visible and the paywall carries the auto-renew disclosure + legal links
+ * (App Store 3.1.2).
  */
 import { useQuery } from "@tanstack/react-query";
 import { Redirect } from "expo-router";
@@ -13,24 +15,31 @@ import { useState } from "react";
 import { ScrollView, Text, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
+import type { PaidPlan } from "@handicappin/billing-core";
 import { tokens } from "@handicappin/tokens/tokens";
 
 import { DataSettledMarker } from "@/components/data-settled";
+import { PaywallDisclosure } from "@/components/billing/paywall-disclosure";
 import { PricingCard } from "@/components/billing/pricing-card";
+import { Button } from "@/components/ui/button";
 import { FormFeedback } from "@/components/ui/form-feedback";
 import { H1 } from "@/components/ui/typography";
 import { promoSlotsQueryOptions } from "@/lib/api/procedures/stripe";
 import { getBillingFromJWT } from "@/lib/auth/jwt";
 import { useSession } from "@/lib/auth/session-provider";
+import {
+  MOCK_PURCHASE_NOTICE,
+  MOCK_RESTORE_PREFIX,
+  purchasePlan,
+  restorePurchases,
+} from "@/lib/billing/purchase-flow";
 import { useDataSettled } from "@/lib/query/settle";
 import { PLAN_DETAILS, PLAN_FEATURES } from "@/lib/billing/plan-content";
-
-const MOCK_PURCHASE_NOTICE =
-  "Purchases aren't available in this development build — select your plan on handicappin.com and it will appear here.";
 
 export default function OnboardingScreen() {
   const { session, initializing } = useSession();
   const [notice, setNotice] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
 
   const promoSlots = useQuery({
     ...promoSlotsQueryOptions(),
@@ -48,9 +57,51 @@ export default function OnboardingScreen() {
     return <Redirect href="/" />;
   }
 
+  const userId = session.user.id;
   const isActiveLifetimePromo = (promoSlots.data?.remaining ?? 0) > 0;
 
+  // Web-only server flows (free-tier selection, EARLY100 promo claim).
   const showMockNotice = () => setNotice(MOCK_PURCHASE_NOTICE);
+
+  const onPurchase = async (plan: PaidPlan) => {
+    setBusy(true);
+    try {
+      const result = await purchasePlan(userId, plan);
+      if (result.kind === "mock-notice") {
+        setNotice(result.message);
+      } else if (result.kind === "purchased") {
+        setNotice(
+          "Purchase complete! Your plan is being activated — pull to refresh in a moment.",
+        );
+      } else if (result.kind === "error") {
+        setNotice(result.message);
+      }
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const onRestore = async () => {
+    setBusy(true);
+    try {
+      const result = await restorePurchases(userId);
+      if (result.kind === "error") {
+        setNotice(result.message);
+        return;
+      }
+      const list =
+        result.activeEntitlements.length > 0
+          ? result.activeEntitlements.join(", ")
+          : "none";
+      setNotice(
+        result.mocked
+          ? `${MOCK_RESTORE_PREFIX} Backend state restored — active entitlements: ${list}.`
+          : `Purchases restored — active entitlements: ${list}.`,
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
 
   return (
     <ScrollView
@@ -106,7 +157,7 @@ export default function OnboardingScreen() {
           features={PLAN_FEATURES["premium"] ?? []}
           buttonText="Subscribe"
           costComparison={PLAN_DETAILS.premium.costComparison}
-          onButtonPress={showMockNotice}
+          onButtonPress={() => void onPurchase("premium")}
         />
         <PricingCard
           testID="plan-unlimited"
@@ -120,7 +171,7 @@ export default function OnboardingScreen() {
           buttonText="Subscribe"
           costComparison={PLAN_DETAILS.unlimited.costComparison}
           highlighted={!isActiveLifetimePromo}
-          onButtonPress={showMockNotice}
+          onButtonPress={() => void onPurchase("unlimited")}
         />
         {isActiveLifetimePromo ? (
           <PricingCard
@@ -148,12 +199,25 @@ export default function OnboardingScreen() {
             title={PLAN_DETAILS.lifetime.title}
             description={PLAN_DETAILS.lifetime.description}
             features={PLAN_FEATURES["lifetime"] ?? []}
-            buttonText="Subscribe"
+            buttonText="Buy Lifetime"
             costComparison={PLAN_DETAILS.lifetime.costComparison}
-            onButtonPress={showMockNotice}
+            onButtonPress={() => void onPurchase("lifetime")}
           />
         )}
       </View>
+
+      {/* §1: Restore always visible on the paywall */}
+      <Button
+        testID="onboarding-restore"
+        variant="outline"
+        disabled={busy}
+        onPress={() => void onRestore()}
+      >
+        Restore Purchases
+      </Button>
+
+      {/* App Store 3.1.2: auto-renew disclosure + legal links */}
+      <PaywallDisclosure />
     </ScrollView>
   );
 }

--- a/apps/native/components/billing/paywall-disclosure.tsx
+++ b/apps/native/components/billing/paywall-disclosure.tsx
@@ -1,0 +1,36 @@
+/**
+ * Paywall compliance block (App Store 3.1.2): auto-renew disclosure copy
+ * plus Terms of Service / Privacy Policy links. Rendered on every surface
+ * that shows purchase buttons (handoff DoD #8).
+ */
+import { Text, View } from "react-native";
+
+import { Button } from "@/components/ui/button";
+import { AUTO_RENEW_DISCLOSURE } from "@/lib/billing/paywall-policy";
+import { openLegalDocument } from "@/lib/legal";
+
+export function PaywallDisclosure() {
+  return (
+    <View className="gap-sm" testID="paywall-disclosure">
+      <Text className="text-meta text-muted-foreground">
+        {AUTO_RENEW_DISCLOSURE}
+      </Text>
+      <View className="flex-row gap-md">
+        <Button
+          variant="link"
+          className="px-0"
+          onPress={() => void openLegalDocument("terms")}
+        >
+          Terms of Service
+        </Button>
+        <Button
+          variant="link"
+          className="px-0"
+          onPress={() => void openLegalDocument("privacy")}
+        >
+          Privacy Policy
+        </Button>
+      </View>
+    </View>
+  );
+}

--- a/apps/native/components/billing/paywall-packages.tsx
+++ b/apps/native/components/billing/paywall-packages.tsx
@@ -99,6 +99,9 @@ export function PaywallPackages({
             size="sm"
             disabled={purchasing !== null}
             onPress={() => void onBuy(pkg)}
+            // Each buy button reads "Subscribe" — give screen readers a label
+            // that names the specific plan and price it purchases.
+            accessibilityLabel={`Subscribe to ${pkg.product.title}, ${pkg.product.priceString}`}
           >
             {purchasing === pkg.identifier ? "…" : "Subscribe"}
           </Button>

--- a/apps/native/components/billing/paywall-packages.tsx
+++ b/apps/native/components/billing/paywall-packages.tsx
@@ -1,0 +1,111 @@
+/**
+ * Compact purchasable plan list — the profile billing tab's "full paywall"
+ * state (§1 matrix: plan null/free → purchasable). Renders the REAL lineup
+ * from the billing seam's offerings; purchases route through the seam
+ * (mock → labelled dev notice, real SDK → App Store sheet).
+ */
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { Text, View } from "react-native";
+
+import { appleSkuToPlan } from "@handicappin/billing-core";
+
+import { PaywallDisclosure } from "@/components/billing/paywall-disclosure";
+import { Button } from "@/components/ui/button";
+import { FormFeedback } from "@/components/ui/form-feedback";
+import { H3 } from "@/components/ui/typography";
+import type { BillingPackage } from "@/lib/billing/types";
+import { loadPackages, purchasePlan } from "@/lib/billing/purchase-flow";
+
+export function PaywallPackages({
+  userId,
+  onPurchased,
+}: {
+  userId: string;
+  /** Called after a REAL (non-mock) purchase completes. */
+  onPurchased?: () => void;
+}) {
+  const [feedback, setFeedback] = useState<{
+    type: "success" | "error" | "info";
+    message: string;
+  } | null>(null);
+  const [purchasing, setPurchasing] = useState<string | null>(null);
+
+  const packagesQuery = useQuery({
+    queryKey: ["billing", "offerings", userId],
+    queryFn: () => loadPackages(userId),
+  });
+
+  const onBuy = async (pkg: BillingPackage) => {
+    const plan = appleSkuToPlan(pkg.product.identifier);
+    if (!plan) return;
+    setPurchasing(pkg.identifier);
+    try {
+      const result = await purchasePlan(userId, plan);
+      if (result.kind === "mock-notice") {
+        setFeedback({ type: "info", message: result.message });
+      } else if (result.kind === "purchased") {
+        setFeedback({
+          type: "success",
+          message: "Purchase complete — your plan is now active.",
+        });
+        onPurchased?.();
+      } else if (result.kind === "error") {
+        setFeedback({ type: "error", message: result.message });
+      }
+    } finally {
+      setPurchasing(null);
+    }
+  };
+
+  return (
+    <View className="surface p-lg rounded-lg gap-md" testID="paywall-packages">
+      <H3>Upgrade Your Plan</H3>
+
+      {feedback ? (
+        <FormFeedback
+          type={feedback.type}
+          message={feedback.message}
+          onClose={() => setFeedback(null)}
+        />
+      ) : null}
+
+      {packagesQuery.isPending ? (
+        <Text className="text-body text-muted-foreground">Loading plans…</Text>
+      ) : null}
+      {packagesQuery.isError ? (
+        <Text className="text-body text-muted-foreground">
+          Plans are unavailable right now.
+        </Text>
+      ) : null}
+
+      {(packagesQuery.data ?? []).map((pkg) => (
+        <View
+          key={pkg.identifier}
+          className="flex-row items-center justify-between gap-md"
+        >
+          <View className="flex-1">
+            <Text className="text-label-sm text-foreground">
+              {pkg.product.title}
+            </Text>
+            <Text className="text-meta text-muted-foreground">
+              {pkg.product.priceString}
+              {pkg.packageType === "ANNUAL" ? " · renews yearly" : ""}
+              {pkg.packageType === "LIFETIME" ? " · one-time" : ""}
+            </Text>
+          </View>
+          <Button
+            testID={`paywall-buy-${pkg.identifier}`}
+            size="sm"
+            disabled={purchasing !== null}
+            onPress={() => void onBuy(pkg)}
+          >
+            {purchasing === pkg.identifier ? "…" : "Subscribe"}
+          </Button>
+        </View>
+      ))}
+
+      <PaywallDisclosure />
+    </View>
+  );
+}

--- a/apps/native/eas.json
+++ b/apps/native/eas.json
@@ -17,7 +17,8 @@
       "env": {
         "EXPO_PUBLIC_SUPABASE_URL": "https://SET-ME.supabase.co",
         "EXPO_PUBLIC_SUPABASE_ANON_KEY": "SET-ME",
-        "EXPO_PUBLIC_API_BASE_URL": "https://handicappin.com"
+        "EXPO_PUBLIC_API_BASE_URL": "https://handicappin.com",
+        "EXPO_PUBLIC_REVENUECAT_IOS_API_KEY": "appl_SET-ME"
       }
     },
     "production": {
@@ -25,7 +26,8 @@
       "env": {
         "EXPO_PUBLIC_SUPABASE_URL": "https://SET-ME.supabase.co",
         "EXPO_PUBLIC_SUPABASE_ANON_KEY": "SET-ME",
-        "EXPO_PUBLIC_API_BASE_URL": "https://handicappin.com"
+        "EXPO_PUBLIC_API_BASE_URL": "https://handicappin.com",
+        "EXPO_PUBLIC_REVENUECAT_IOS_API_KEY": "appl_SET-ME"
       }
     }
   },

--- a/apps/native/lib/api/schemas/profile.ts
+++ b/apps/native/lib/api/schemas/profile.ts
@@ -26,6 +26,9 @@ export const subscriptionStatusSchema = z.enum([
 ]);
 export type SubscriptionStatus = z.infer<typeof subscriptionStatusSchema>;
 
+export const billingProviderSchema = z.enum(["stripe", "apple"]);
+export type BillingProviderId = z.infer<typeof billingProviderSchema>;
+
 export const profileSchema = z.object({
   id: z.string(),
   email: z.string(),
@@ -40,6 +43,8 @@ export const profileSchema = z.object({
   current_period_end: z.number().nullable(),
   cancel_at_period_end: z.boolean(),
   billing_version: z.number(),
+  // Tolerant of older web servers that don't send the column yet.
+  billing_provider: billingProviderSchema.nullable().optional().default(null),
 });
 
 export type Profile = z.infer<typeof profileSchema>;

--- a/apps/native/lib/billing/index.ts
+++ b/apps/native/lib/billing/index.ts
@@ -1,15 +1,26 @@
 /**
- * THE billing seam. Screens import `billing` from here and nothing else;
- * swapping the mock for the real `react-native-purchases` SDK is a change to
- * this file only (decision ledger §1).
+ * THE billing seam. Screens import `billing` from here and nothing else.
  *
- * The mock reads the user's REAL subscription state through tRPC: the
- * profile row carries plan/status/period (kept fresh by the web's Stripe
- * webhooks), so what the native paywall/profile shows matches the backend.
+ * Provider selection (decision ledger D-seam): the factory keys off
+ * EXPO_PUBLIC_REVENUECAT_IOS_API_KEY —
+ *   - absent (CI, sim verification, key-less dev builds) → the
+ *     RevenueCat-shaped MOCK: real subscription STATE via tRPC, purchase/
+ *     restore flows surface a labelled dev notice;
+ *   - present (owner builds, after RC console setup) → the real
+ *     react-native-purchases SDK. The SDK module is required lazily so a
+ *     key-less app never evaluates it.
+ *
+ * Either way the backend projection stays the entitlement source of truth
+ * (D-arch) — the RC webhook feeds it; screens read it via tRPC.
  */
 import { trpcQuery } from "@/lib/api/client";
 import { profileSchema } from "@/lib/api/schemas/profile";
+import { env } from "@/lib/env";
 import { MockBillingProvider } from "@/lib/billing/mock-provider";
+import {
+  selectBillingProviderKind,
+  type BillingProviderKind,
+} from "@/lib/billing/select-provider";
 import type {
   BillingProvider,
   SubscriptionState,
@@ -32,11 +43,34 @@ async function fetchSubscriptionStateViaTrpc(
   };
 }
 
-export const billing: BillingProvider = new MockBillingProvider(
-  fetchSubscriptionStateViaTrpc,
-  (message) => {
-    if (__DEV__) console.log(message); // allow-console dev-only mock telemetry
-  },
-);
+function createBillingProvider(): {
+  provider: BillingProvider;
+  kind: BillingProviderKind;
+} {
+  const apiKey = env.revenueCatIosApiKey;
+  if (apiKey && selectBillingProviderKind(apiKey) === "revenuecat") {
+    // Lazy require keeps the SDK (a native module) out of the eval path for
+    // key-less builds — they must boot without it (D-seam).
+    const { RevenueCatBillingProvider } =
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      require("@/lib/billing/revenuecat-provider") as typeof import("@/lib/billing/revenuecat-provider");
+    return {
+      provider: new RevenueCatBillingProvider(apiKey),
+      kind: "revenuecat",
+    };
+  }
+  return {
+    provider: new MockBillingProvider(fetchSubscriptionStateViaTrpc, (message) => {
+      if (__DEV__) console.log(message); // allow-console dev-only mock telemetry
+    }),
+    kind: "mock",
+  };
+}
 
+const selected = createBillingProvider();
+
+export const billing: BillingProvider = selected.provider;
+export const billingProviderKind: BillingProviderKind = selected.kind;
+
+export type { BillingProviderKind } from "@/lib/billing/select-provider";
 export type { BillingProvider } from "@/lib/billing/types";

--- a/apps/native/lib/billing/mock-provider.ts
+++ b/apps/native/lib/billing/mock-provider.ts
@@ -8,6 +8,8 @@
  * mirror the web upgrade page's plan lineup so the paywall renders something
  * truthful about what exists, with placeholder prices labelled as such.
  */
+import { APPLE_SKUS } from "@handicappin/billing-core";
+
 import type {
   BillingCustomerInfo,
   BillingEntitlement,
@@ -21,29 +23,35 @@ export type SubscriptionStateFetcher = (
   userId: string,
 ) => Promise<SubscriptionState>;
 
+/**
+ * The REAL product lineup (decision ledger D-products): premium yearly,
+ * unlimited yearly, lifetime — no monthly. SKUs come from the shared
+ * constants module; prices mirror web's PLAN_PRICING. Only the purchase
+ * FLOW is mocked — what's on offer is truthful.
+ */
 const MOCK_OFFERINGS: BillingOfferings = (() => {
   const packages: BillingPackage[] = [
     {
-      identifier: "$rc_monthly",
-      packageType: "MONTHLY",
+      identifier: "premium_yearly",
+      packageType: "ANNUAL",
       offeringIdentifier: "default",
       product: {
-        identifier: "premium_monthly",
+        identifier: APPLE_SKUS.premiumYearly,
         title: "Premium",
-        description: "Dashboard and calculators access",
-        priceString: "$3.99/mo (mock)",
+        description: "For golf enthusiasts",
+        priceString: "$19/yr",
         currencyCode: "USD",
       },
     },
     {
-      identifier: "$rc_annual",
+      identifier: "unlimited_yearly",
       packageType: "ANNUAL",
       offeringIdentifier: "default",
       product: {
-        identifier: "unlimited_annual",
+        identifier: APPLE_SKUS.unlimitedYearly,
         title: "Unlimited",
-        description: "Unlimited rounds, dashboard, and calculators",
-        priceString: "$29.99/yr (mock)",
+        description: "Unlimited rounds, statistics, and calculators",
+        priceString: "$29/yr",
         currencyCode: "USD",
       },
     },
@@ -52,10 +60,10 @@ const MOCK_OFFERINGS: BillingOfferings = (() => {
       packageType: "LIFETIME",
       offeringIdentifier: "default",
       product: {
-        identifier: "lifetime",
+        identifier: APPLE_SKUS.lifetime,
         title: "Lifetime",
-        description: "Everything, forever",
-        priceString: "$79.99 (mock)",
+        description: "Unlimited access, forever",
+        priceString: "$149",
         currencyCode: "USD",
       },
     },
@@ -63,13 +71,13 @@ const MOCK_OFFERINGS: BillingOfferings = (() => {
   return {
     current: {
       identifier: "default",
-      serverDescription: "Mock offering mirroring the web plan lineup",
+      serverDescription: "The real plan lineup (D-products); purchase flow mocked",
       availablePackages: packages,
     },
     all: {
       default: {
         identifier: "default",
-        serverDescription: "Mock offering mirroring the web plan lineup",
+        serverDescription: "The real plan lineup (D-products); purchase flow mocked",
         availablePackages: packages,
       },
     },

--- a/apps/native/lib/billing/paywall-policy.ts
+++ b/apps/native/lib/billing/paywall-policy.ts
@@ -1,0 +1,113 @@
+/**
+ * The §1 paywall policy matrix (decision ledger D-policy / D-paywall,
+ * LOCKED) as a pure function over the user's REAL billing projection:
+ *
+ * | Projection state          | Native paywall                              |
+ * |---------------------------|---------------------------------------------|
+ * | plan null/free            | full paywall (purchasable)                  |
+ * | active + provider apple   | native plan change + Apple manage link      |
+ * | active + provider stripe  | no purchase buttons; neutral copy (NO link) |
+ * | lifetime (any provider)   | no purchase buttons                         |
+ * | always                    | Restore Purchases                           |
+ *
+ * Non-active paid states (past_due, canceled-in-grace) keep their
+ * provider's management affordance and never show purchase buttons — the
+ * contract still exists; buying again would double-bill (logged D26).
+ */
+import type {
+  BillingProviderId,
+  PlanType,
+  SubscriptionStatus,
+} from "@/lib/api/schemas/profile";
+
+export interface BillingProjectionState {
+  plan: PlanType | null;
+  status: SubscriptionStatus | null;
+  provider: BillingProviderId | null;
+  cancelAtPeriodEnd: boolean;
+}
+
+export interface PaywallPolicy {
+  /** Full paywall: the real lineup with purchase CTAs through the seam. */
+  showPurchaseButtons: boolean;
+  /** Apple-billed: native upgrade/downgrade within the subscription group. */
+  showNativePlanChange: boolean;
+  /** Apple-billed: manage-subscriptions affordance (managementURL). */
+  showAppleManage: boolean;
+  /** Stripe-billed: neutral "managed on handicappin.com" copy, NO link. */
+  showStripeNeutralCopy: boolean;
+  /** Always true (§1: Restore always visible). */
+  showRestore: true;
+  /** Paywall compliance block (auto-renew disclosure + legal links). */
+  showDisclosure: boolean;
+}
+
+function isPaidPlan(plan: PlanType | null): boolean {
+  return plan === "premium" || plan === "unlimited" || plan === "lifetime";
+}
+
+export function paywallPolicyFor(
+  state: BillingProjectionState,
+): PaywallPolicy {
+  // Lifetime (any provider): no purchase buttons, nothing to manage.
+  if (state.plan === "lifetime") {
+    return {
+      showPurchaseButtons: false,
+      showNativePlanChange: false,
+      showAppleManage: false,
+      showStripeNeutralCopy: false,
+      showRestore: true,
+      showDisclosure: false,
+    };
+  }
+
+  // No contract (null or free tier): full paywall, purchasable.
+  if (!isPaidPlan(state.plan)) {
+    return {
+      showPurchaseButtons: true,
+      showNativePlanChange: false,
+      showAppleManage: false,
+      showStripeNeutralCopy: false,
+      showRestore: true,
+      showDisclosure: true,
+    };
+  }
+
+  // Paid subscription (active OR in a non-active contract state like
+  // past_due / canceled-in-grace): the owning provider manages it.
+  if (state.provider === "apple") {
+    const active = state.status === "active" || state.status === "trialing";
+    return {
+      showPurchaseButtons: false,
+      // Plan change happens where the subscription lives (Policy A) — only
+      // offered while the contract is actually active.
+      showNativePlanChange: active,
+      showAppleManage: true,
+      showStripeNeutralCopy: false,
+      showRestore: true,
+      showDisclosure: active,
+    };
+  }
+
+  // Stripe-billed (or legacy rows with provider null + a paid plan, which
+  // predate billing_provider and are all stripe-billed): neutral copy.
+  return {
+    showPurchaseButtons: false,
+    showNativePlanChange: false,
+    showAppleManage: false,
+    showStripeNeutralCopy: true,
+    showRestore: true,
+    showDisclosure: false,
+  };
+}
+
+/** §1 D-policy copy — neutral, and deliberately NOT a link. */
+export const STRIPE_NEUTRAL_COPY =
+  "Your subscription is managed on handicappin.com.";
+
+/** Paywall compliance copy (App Store 3.1.2 auto-renew disclosure). */
+export const AUTO_RENEW_DISCLOSURE =
+  "Yearly subscriptions renew automatically until cancelled. Payment is " +
+  "charged to your Apple ID account; manage or cancel anytime in App Store " +
+  "subscription settings. The lifetime plan is a one-time purchase and does " +
+  "not renew.";

--- a/apps/native/lib/billing/purchase-flow.ts
+++ b/apps/native/lib/billing/purchase-flow.ts
@@ -1,0 +1,123 @@
+/**
+ * Purchase/restore orchestration over the billing seam — shared by the
+ * onboarding paywall and the profile billing tab. Screens stay declarative;
+ * this module owns the configure → offerings → purchase dance and the
+ * mock-mode labelling (decision ledger: mocked flows must say so out loud).
+ */
+import { planToAppleSku, type PaidPlan } from "@handicappin/billing-core";
+
+import { billing, billingProviderKind } from "@/lib/billing";
+import type { BillingCustomerInfo, BillingPackage } from "@/lib/billing/types";
+
+export const MOCK_PURCHASE_NOTICE =
+  "Purchases aren't available in this development build — select your plan on handicappin.com and it will appear here.";
+
+export const MOCK_RESTORE_PREFIX = "Dev build: purchases are mocked.";
+
+export type PurchaseFlowResult =
+  | { kind: "mock-notice"; message: string }
+  | { kind: "purchased"; customerInfo: BillingCustomerInfo }
+  | { kind: "cancelled" }
+  | { kind: "error"; message: string };
+
+/** Narrow unknown SDK errors; RC user-cancellations carry userCancelled. */
+function isUserCancelled(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "userCancelled" in error &&
+    Boolean((error as { userCancelled: unknown }).userCancelled)
+  );
+}
+
+export async function loadPackages(
+  userId: string,
+): Promise<BillingPackage[]> {
+  await billing.configure({ appUserID: userId });
+  const offerings = await billing.getOfferings();
+  return offerings.current?.availablePackages ?? [];
+}
+
+export function packageForPlan(
+  packages: BillingPackage[],
+  plan: PaidPlan,
+): BillingPackage | null {
+  const sku = planToAppleSku(plan);
+  return packages.find((pkg) => pkg.product.identifier === sku) ?? null;
+}
+
+/**
+ * Purchase the package for a paid plan. In mock mode this performs NO
+ * purchase — it returns the labelled dev notice for the UI to surface.
+ */
+export async function purchasePlan(
+  userId: string,
+  plan: PaidPlan,
+): Promise<PurchaseFlowResult> {
+  if (billingProviderKind === "mock") {
+    return { kind: "mock-notice", message: MOCK_PURCHASE_NOTICE };
+  }
+  try {
+    const packages = await loadPackages(userId);
+    const pkg = packageForPlan(packages, plan);
+    if (!pkg) {
+      return {
+        kind: "error",
+        message:
+          "This plan isn't available right now. Please try again later.",
+      };
+    }
+    const { customerInfo } = await billing.purchasePackage(pkg);
+    return { kind: "purchased", customerInfo };
+  } catch (error) {
+    if (isUserCancelled(error)) return { kind: "cancelled" };
+    return {
+      kind: "error",
+      message:
+        error instanceof Error ? error.message : "Purchase failed. Try again.",
+    };
+  }
+}
+
+export type RestoreFlowResult =
+  | { kind: "restored"; activeEntitlements: string[]; mocked: boolean }
+  | { kind: "error"; message: string };
+
+/** Restore purchases — always available (§1: Restore always visible). */
+export async function restorePurchases(
+  userId: string,
+): Promise<RestoreFlowResult> {
+  try {
+    await billing.configure({ appUserID: userId });
+    const info = await billing.restorePurchases();
+    return {
+      kind: "restored",
+      activeEntitlements: Object.keys(info.entitlements.active),
+      mocked: billingProviderKind === "mock",
+    };
+  } catch (error) {
+    return {
+      kind: "error",
+      message:
+        error instanceof Error ? error.message : "Restore failed. Try again.",
+    };
+  }
+}
+
+/**
+ * Apple's manage-subscriptions surface: prefer the account-scoped
+ * managementURL from CustomerInfo; fall back to the canonical
+ * subscriptions URL (works on device and sim).
+ */
+export const APPLE_MANAGE_SUBSCRIPTIONS_URL =
+  "https://apps.apple.com/account/subscriptions";
+
+export async function getManagementUrl(userId: string): Promise<string> {
+  try {
+    await billing.configure({ appUserID: userId });
+    const info = await billing.getCustomerInfo();
+    return info.managementURL ?? APPLE_MANAGE_SUBSCRIPTIONS_URL;
+  } catch {
+    return APPLE_MANAGE_SUBSCRIPTIONS_URL;
+  }
+}

--- a/apps/native/lib/billing/revenuecat-mapping.ts
+++ b/apps/native/lib/billing/revenuecat-mapping.ts
@@ -1,0 +1,129 @@
+/**
+ * Pure structural mapping: react-native-purchases SDK shapes → the app's
+ * BillingProvider contract types. NO SDK imports — the inputs are minimal
+ * structural mirrors of the SDK types, so this module is unit-testable in
+ * plain node (the SDK itself needs a native runtime).
+ */
+import type {
+  BillingCustomerInfo,
+  BillingEntitlement,
+  BillingOffering,
+  BillingOfferings,
+  BillingPackage,
+  BillingPackageType,
+} from "@/lib/billing/types";
+
+/** Structural mirror of the SDK's PurchasesStoreProduct (fields we use). */
+export interface RcStoreProductShape {
+  identifier: string;
+  title: string;
+  description: string;
+  priceString: string;
+  currencyCode: string;
+}
+
+/** Structural mirror of the SDK's PurchasesPackage (fields we use). */
+export interface RcPackageShape {
+  identifier: string;
+  packageType: string;
+  offeringIdentifier: string;
+  product: RcStoreProductShape;
+}
+
+/** Structural mirror of the SDK's PurchasesOffering. */
+export interface RcOfferingShape {
+  identifier: string;
+  serverDescription: string;
+  availablePackages: RcPackageShape[];
+}
+
+/** Structural mirror of the SDK's PurchasesOfferings. */
+export interface RcOfferingsShape {
+  current: RcOfferingShape | null;
+  all: Record<string, RcOfferingShape>;
+}
+
+/** Structural mirror of the SDK's PurchasesEntitlementInfo. */
+export interface RcEntitlementShape {
+  identifier: string;
+  isActive: boolean;
+  productIdentifier: string;
+  expirationDate: string | null;
+  willRenew: boolean;
+}
+
+/** Structural mirror of the SDK's CustomerInfo. */
+export interface RcCustomerInfoShape {
+  originalAppUserId: string;
+  activeSubscriptions: string[];
+  entitlements: { active: Record<string, RcEntitlementShape> };
+  managementURL: string | null;
+}
+
+const KNOWN_PACKAGE_TYPES: ReadonlySet<BillingPackageType> = new Set([
+  "MONTHLY",
+  "ANNUAL",
+  "LIFETIME",
+  "CUSTOM",
+]);
+
+function toBillingPackageType(sdkType: string): BillingPackageType {
+  return KNOWN_PACKAGE_TYPES.has(sdkType as BillingPackageType)
+    ? (sdkType as BillingPackageType)
+    : "CUSTOM";
+}
+
+export function mapRcPackage(pkg: RcPackageShape): BillingPackage {
+  return {
+    identifier: pkg.identifier,
+    packageType: toBillingPackageType(pkg.packageType),
+    offeringIdentifier: pkg.offeringIdentifier,
+    product: {
+      identifier: pkg.product.identifier,
+      title: pkg.product.title,
+      description: pkg.product.description,
+      priceString: pkg.product.priceString,
+      currencyCode: pkg.product.currencyCode,
+    },
+  };
+}
+
+function mapRcOffering(offering: RcOfferingShape): BillingOffering {
+  return {
+    identifier: offering.identifier,
+    serverDescription: offering.serverDescription,
+    availablePackages: offering.availablePackages.map(mapRcPackage),
+  };
+}
+
+export function mapRcOfferings(offerings: RcOfferingsShape): BillingOfferings {
+  const all: Record<string, BillingOffering> = {};
+  for (const [key, offering] of Object.entries(offerings.all)) {
+    all[key] = mapRcOffering(offering);
+  }
+  return {
+    current: offerings.current ? mapRcOffering(offerings.current) : null,
+    all,
+  };
+}
+
+export function mapRcCustomerInfo(
+  info: RcCustomerInfoShape,
+): BillingCustomerInfo {
+  const active: Record<string, BillingEntitlement> = {};
+  for (const [key, ent] of Object.entries(info.entitlements.active)) {
+    active[key] = {
+      identifier: ent.identifier,
+      isActive: ent.isActive,
+      productIdentifier: ent.productIdentifier,
+      expirationDate: ent.expirationDate,
+      willRenew: ent.willRenew,
+    };
+  }
+  return {
+    originalAppUserId: info.originalAppUserId,
+    activeSubscriptions: [...info.activeSubscriptions],
+    entitlements: { active },
+    managementURL: info.managementURL,
+  };
+}

--- a/apps/native/lib/billing/revenuecat-provider.ts
+++ b/apps/native/lib/billing/revenuecat-provider.ts
@@ -1,0 +1,101 @@
+/**
+ * REAL RevenueCat billing provider (decision ledger D-rc-scope): Apple-side
+ * plumbing only — purchasing, receipt validation, restore. RC is NEVER the
+ * entitlement source of truth; the backend projection (fed by the RC
+ * webhook) stays authoritative and screens keep reading it via tRPC.
+ *
+ * This module is loaded by lib/billing/index.ts ONLY when
+ * EXPO_PUBLIC_REVENUECAT_IOS_API_KEY is set (D-seam) — keeping the SDK's
+ * native module out of the eval path for key-less builds (CI, sim
+ * verification), which run the mock and never touch this file at runtime.
+ */
+import Purchases, { LOG_LEVEL } from "react-native-purchases";
+
+import type {
+  BillingCustomerInfo,
+  BillingOfferings,
+  BillingPackage,
+  BillingProvider,
+} from "@/lib/billing/types";
+import {
+  mapRcCustomerInfo,
+  mapRcOfferings,
+} from "@/lib/billing/revenuecat-mapping";
+
+export class RevenueCatBillingProvider implements BillingProvider {
+  private readonly apiKey: string;
+  private configured = false;
+  /** Native package objects from the last getOfferings(), by identifier —
+   * purchasePackage must hand the SDK its own object back. */
+  private nativePackages = new Map<string, unknown>();
+
+  constructor(apiKey: string) {
+    if (!apiKey) {
+      // D-seam: the SDK must never be configured without a key. The factory
+      // guarantees this; the throw guards direct construction.
+      throw new Error(
+        "RevenueCatBillingProvider requires EXPO_PUBLIC_REVENUECAT_IOS_API_KEY",
+      );
+    }
+    this.apiKey = apiKey;
+  }
+
+  async configure(options: { appUserID: string }): Promise<void> {
+    if (!this.configured) {
+      if (__DEV__) {
+        await Purchases.setLogLevel(LOG_LEVEL.DEBUG);
+      }
+      // app_user_id IS the Supabase user id (D-rc-scope): configure
+      // anonymously, then logIn binds the store receipt to our user id.
+      Purchases.configure({ apiKey: this.apiKey });
+      this.configured = true;
+    }
+    await Purchases.logIn(options.appUserID);
+  }
+
+  async getOfferings(): Promise<BillingOfferings> {
+    this.requireConfigured("getOfferings");
+    const offerings = await Purchases.getOfferings();
+    this.nativePackages.clear();
+    for (const offering of Object.values(offerings.all)) {
+      for (const pkg of offering.availablePackages) {
+        this.nativePackages.set(pkg.identifier, pkg);
+      }
+    }
+    return mapRcOfferings(offerings);
+  }
+
+  async getCustomerInfo(): Promise<BillingCustomerInfo> {
+    this.requireConfigured("getCustomerInfo");
+    return mapRcCustomerInfo(await Purchases.getCustomerInfo());
+  }
+
+  async purchasePackage(
+    pkg: BillingPackage,
+  ): Promise<{ customerInfo: BillingCustomerInfo }> {
+    this.requireConfigured("purchasePackage");
+    const nativePkg = this.nativePackages.get(pkg.identifier);
+    if (!nativePkg) {
+      throw new Error(
+        `Unknown package ${pkg.identifier} — call getOfferings() before purchasePackage()`,
+      );
+    }
+    const result = await Purchases.purchasePackage(
+      nativePkg as Parameters<typeof Purchases.purchasePackage>[0],
+    );
+    return { customerInfo: mapRcCustomerInfo(result.customerInfo) };
+  }
+
+  async restorePurchases(): Promise<BillingCustomerInfo> {
+    this.requireConfigured("restorePurchases");
+    return mapRcCustomerInfo(await Purchases.restorePurchases());
+  }
+
+  private requireConfigured(method: string): void {
+    if (!this.configured) {
+      throw new Error(
+        `RevenueCatBillingProvider.${method} called before configure() — call configure({appUserID}) after login`,
+      );
+    }
+  }
+}

--- a/apps/native/lib/billing/revenuecat-provider.ts
+++ b/apps/native/lib/billing/revenuecat-provider.ts
@@ -24,6 +24,11 @@ import {
 
 export class RevenueCatBillingProvider implements BillingProvider {
   private readonly apiKey: string;
+  /** SDK-level `Purchases.configure()` is one-shot and must not repeat. */
+  private sdkConfigured = false;
+  /** "Ready for purchases" — true ONLY after logIn() binds the store receipt
+   * to our Supabase user id. A logIn() failure must leave this false so the
+   * requireConfigured guard blocks purchases against the anonymous RC user. */
   private configured = false;
   /** Native package objects from the last getOfferings(), by identifier —
    * purchasePackage must hand the SDK its own object back. */
@@ -41,16 +46,21 @@ export class RevenueCatBillingProvider implements BillingProvider {
   }
 
   async configure(options: { appUserID: string }): Promise<void> {
-    if (!this.configured) {
+    if (!this.sdkConfigured) {
       if (__DEV__) {
         await Purchases.setLogLevel(LOG_LEVEL.DEBUG);
       }
       // app_user_id IS the Supabase user id (D-rc-scope): configure
       // anonymously, then logIn binds the store receipt to our user id.
       Purchases.configure({ apiKey: this.apiKey });
-      this.configured = true;
+      this.sdkConfigured = true;
     }
+    // Only mark purchase-ready AFTER logIn resolves. If it throws (network /
+    // RC outage), `configured` stays false and the next call re-runs logIn —
+    // a purchase can never fire against the anonymous $RCAnonymousID user,
+    // whose INITIAL_PURCHASE webhook the backend rejects as non-UUID.
     await Purchases.logIn(options.appUserID);
+    this.configured = true;
   }
 
   async getOfferings(): Promise<BillingOfferings> {

--- a/apps/native/lib/billing/select-provider.ts
+++ b/apps/native/lib/billing/select-provider.ts
@@ -1,0 +1,15 @@
+/**
+ * D-seam selection rule, isolated pure so it's unit-testable without the
+ * Expo runtime: the REAL RevenueCat SDK is used iff a non-empty iOS API key
+ * is configured; otherwise the mock. The SDK must never be configured
+ * without a key.
+ */
+export type BillingProviderKind = "revenuecat" | "mock";
+
+export function selectBillingProviderKind(
+  revenueCatIosApiKey: string | null | undefined,
+): BillingProviderKind {
+  return revenueCatIosApiKey && revenueCatIosApiKey.length > 0
+    ? "revenuecat"
+    : "mock";
+}

--- a/apps/native/lib/env.ts
+++ b/apps/native/lib/env.ts
@@ -17,6 +17,13 @@ const envSchema = z.object({
   supabaseAnonKey: z.string().min(1),
   /** Base URL of the Next.js app serving /api/trpc (dev: http://localhost:3000). */
   apiBaseUrl: z.url(),
+  /**
+   * RevenueCat iOS public SDK key (appl_...). THE billing-provider switch
+   * (decision ledger D-seam): absent → mock provider (CI, sim verification);
+   * present → real react-native-purchases SDK. Client-exposed by design
+   * (RC public SDK keys are not secrets).
+   */
+  revenueCatIosApiKey: z.string().min(1).nullable(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/native/lib/env.ts
+++ b/apps/native/lib/env.ts
@@ -22,8 +22,16 @@ const envSchema = z.object({
    * (decision ledger D-seam): absent → mock provider (CI, sim verification);
    * present → real react-native-purchases SDK. Client-exposed by design
    * (RC public SDK keys are not secrets).
+   *
+   * Preprocessed because "absent" arrives in several shapes: the key is
+   * omitted from fresh manifests, but Expo's config serializer turns null
+   * extras into {} (and dev clients embed a build-time snapshot), so any
+   * non-string here means "no key" — never crash the boot over it.
    */
-  revenueCatIosApiKey: z.string().min(1).nullable(),
+  revenueCatIosApiKey: z.preprocess(
+    (value) => (typeof value === "string" && value.length > 0 ? value : null),
+    z.string().min(1).nullable(),
+  ),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -57,6 +57,7 @@
     "react-native": "0.85.3",
     "react-native-css": "^3.0.7",
     "react-native-gesture-handler": "~2.31.1",
+    "react-native-purchases": "^10.3.0",
     "react-native-reanimated": "4.3.1",
     "react-native-safe-area-context": "~5.7.0",
     "react-native-screens": "4.25.2",

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@expo-google-fonts/inter": "^0.4.2",
     "@expo/ui": "~56.0.16",
+    "@handicappin/billing-core": "workspace:*",
     "@handicappin/handicap-core": "workspace:*",
     "@handicappin/tokens": "workspace:*",
     "@hookform/resolvers": "^5.2.2",

--- a/apps/native/tests/unit/paywall-policy.test.ts
+++ b/apps/native/tests/unit/paywall-policy.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests — lib/billing/paywall-policy (the LOCKED §1 matrix) and the
+ * D-seam provider selection rule.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  paywallPolicyFor,
+  type BillingProjectionState,
+} from "../../lib/billing/paywall-policy";
+import { selectBillingProviderKind } from "../../lib/billing/select-provider";
+
+const state = (
+  overrides: Partial<BillingProjectionState>,
+): BillingProjectionState => ({
+  plan: null,
+  status: null,
+  provider: null,
+  cancelAtPeriodEnd: false,
+  ...overrides,
+});
+
+describe("paywallPolicyFor — §1 matrix", () => {
+  it("plan null → full paywall (purchasable), restore, disclosure", () => {
+    const policy = paywallPolicyFor(state({}));
+    assert.equal(policy.showPurchaseButtons, true);
+    assert.equal(policy.showNativePlanChange, false);
+    assert.equal(policy.showAppleManage, false);
+    assert.equal(policy.showStripeNeutralCopy, false);
+    assert.equal(policy.showRestore, true);
+    assert.equal(policy.showDisclosure, true);
+  });
+
+  it("plan free → full paywall (purchasable)", () => {
+    const policy = paywallPolicyFor(
+      state({ plan: "free", status: "active" }),
+    );
+    assert.equal(policy.showPurchaseButtons, true);
+    assert.equal(policy.showRestore, true);
+  });
+
+  it("active + provider apple → native plan change + Apple manage link", () => {
+    const policy = paywallPolicyFor(
+      state({ plan: "premium", status: "active", provider: "apple" }),
+    );
+    assert.equal(policy.showPurchaseButtons, false);
+    assert.equal(policy.showNativePlanChange, true);
+    assert.equal(policy.showAppleManage, true);
+    assert.equal(policy.showStripeNeutralCopy, false);
+    assert.equal(policy.showRestore, true);
+  });
+
+  it("trialing + apple counts as active for plan change", () => {
+    const policy = paywallPolicyFor(
+      state({ plan: "unlimited", status: "trialing", provider: "apple" }),
+    );
+    assert.equal(policy.showNativePlanChange, true);
+  });
+
+  it("apple + cancel_at_period_end (still active) keeps plan change + manage", () => {
+    const policy = paywallPolicyFor(
+      state({
+        plan: "unlimited",
+        status: "active",
+        provider: "apple",
+        cancelAtPeriodEnd: true,
+      }),
+    );
+    assert.equal(policy.showNativePlanChange, true);
+    assert.equal(policy.showAppleManage, true);
+    assert.equal(policy.showPurchaseButtons, false);
+  });
+
+  it("apple past_due → manage link but NO plan change, NO purchase buttons", () => {
+    const policy = paywallPolicyFor(
+      state({ plan: "premium", status: "past_due", provider: "apple" }),
+    );
+    assert.equal(policy.showPurchaseButtons, false);
+    assert.equal(policy.showNativePlanChange, false);
+    assert.equal(policy.showAppleManage, true);
+    assert.equal(policy.showRestore, true);
+  });
+
+  it("active + provider stripe → neutral copy, no purchase buttons", () => {
+    const policy = paywallPolicyFor(
+      state({ plan: "premium", status: "active", provider: "stripe" }),
+    );
+    assert.equal(policy.showPurchaseButtons, false);
+    assert.equal(policy.showNativePlanChange, false);
+    assert.equal(policy.showAppleManage, false);
+    assert.equal(policy.showStripeNeutralCopy, true);
+    assert.equal(policy.showRestore, true);
+  });
+
+  it("stripe past_due → neutral copy, no purchase buttons", () => {
+    const policy = paywallPolicyFor(
+      state({ plan: "unlimited", status: "past_due", provider: "stripe" }),
+    );
+    assert.equal(policy.showStripeNeutralCopy, true);
+    assert.equal(policy.showPurchaseButtons, false);
+  });
+
+  it("legacy paid rows with provider null are treated as stripe-billed", () => {
+    const policy = paywallPolicyFor(
+      state({ plan: "unlimited", status: "active", provider: null }),
+    );
+    assert.equal(policy.showStripeNeutralCopy, true);
+    assert.equal(policy.showPurchaseButtons, false);
+  });
+
+  it("lifetime (stripe) → no purchase buttons, nothing to manage, restore stays", () => {
+    const policy = paywallPolicyFor(
+      state({ plan: "lifetime", status: "active", provider: "stripe" }),
+    );
+    assert.equal(policy.showPurchaseButtons, false);
+    assert.equal(policy.showNativePlanChange, false);
+    assert.equal(policy.showAppleManage, false);
+    assert.equal(policy.showStripeNeutralCopy, false);
+    assert.equal(policy.showRestore, true);
+  });
+
+  it("lifetime (apple) → same as stripe lifetime", () => {
+    const policy = paywallPolicyFor(
+      state({ plan: "lifetime", status: "active", provider: "apple" }),
+    );
+    assert.equal(policy.showPurchaseButtons, false);
+    assert.equal(policy.showAppleManage, false);
+    assert.equal(policy.showRestore, true);
+  });
+});
+
+describe("selectBillingProviderKind — D-seam", () => {
+  it("no key → mock (CI, sim verification)", () => {
+    assert.equal(selectBillingProviderKind(null), "mock");
+    assert.equal(selectBillingProviderKind(undefined), "mock");
+    assert.equal(selectBillingProviderKind(""), "mock");
+  });
+
+  it("key present → real SDK", () => {
+    assert.equal(selectBillingProviderKind("appl_abc123"), "revenuecat");
+  });
+});

--- a/apps/native/tests/unit/revenuecat-mapping.test.ts
+++ b/apps/native/tests/unit/revenuecat-mapping.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests — lib/billing/revenuecat-mapping (pure SDK-shape → contract
+ * mapping; the SDK itself needs a native runtime so the provider is
+ * exercised structurally, per the handoff).
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  mapRcCustomerInfo,
+  mapRcOfferings,
+  mapRcPackage,
+  type RcCustomerInfoShape,
+  type RcOfferingsShape,
+} from "../../lib/billing/revenuecat-mapping";
+
+const offerings: RcOfferingsShape = {
+  current: {
+    identifier: "default",
+    serverDescription: "Standard set",
+    availablePackages: [
+      {
+        identifier: "premium_yearly",
+        packageType: "ANNUAL",
+        offeringIdentifier: "default",
+        product: {
+          identifier: "com.handicappin.premium.yearly",
+          title: "Premium",
+          description: "For golf enthusiasts",
+          priceString: "$19.00",
+          currencyCode: "USD",
+        },
+      },
+      {
+        identifier: "$rc_lifetime",
+        packageType: "LIFETIME",
+        offeringIdentifier: "default",
+        product: {
+          identifier: "com.handicappin.lifetime",
+          title: "Lifetime",
+          description: "Forever",
+          priceString: "$149.00",
+          currencyCode: "USD",
+        },
+      },
+    ],
+  },
+  all: {},
+};
+offerings.all["default"] = offerings.current!;
+
+describe("mapRcOfferings", () => {
+  it("maps current + all with packages and products intact", () => {
+    const mapped = mapRcOfferings(offerings);
+    assert.equal(mapped.current?.identifier, "default");
+    assert.equal(mapped.current?.availablePackages.length, 2);
+    assert.equal(
+      mapped.current?.availablePackages[0]?.product.identifier,
+      "com.handicappin.premium.yearly",
+    );
+    assert.equal(mapped.all["default"]?.availablePackages.length, 2);
+  });
+
+  it("maps null current offering", () => {
+    const mapped = mapRcOfferings({ current: null, all: {} });
+    assert.equal(mapped.current, null);
+    assert.deepEqual(mapped.all, {});
+  });
+
+  it("normalizes unknown package types to CUSTOM", () => {
+    const pkg = mapRcPackage({
+      identifier: "weird",
+      packageType: "SIX_MONTH",
+      offeringIdentifier: "default",
+      product: {
+        identifier: "p",
+        title: "t",
+        description: "d",
+        priceString: "$1",
+        currencyCode: "USD",
+      },
+    });
+    assert.equal(pkg.packageType, "CUSTOM");
+  });
+});
+
+describe("mapRcCustomerInfo", () => {
+  it("maps entitlements, subscriptions and managementURL", () => {
+    const info: RcCustomerInfoShape = {
+      originalAppUserId: "user-123",
+      activeSubscriptions: ["com.handicappin.premium.yearly"],
+      entitlements: {
+        active: {
+          premium: {
+            identifier: "premium",
+            isActive: true,
+            productIdentifier: "com.handicappin.premium.yearly",
+            expirationDate: "2027-06-12T00:00:00Z",
+            willRenew: true,
+          },
+        },
+      },
+      managementURL: "https://apps.apple.com/account/subscriptions",
+    };
+    const mapped = mapRcCustomerInfo(info);
+    assert.equal(mapped.originalAppUserId, "user-123");
+    assert.deepEqual(mapped.activeSubscriptions, [
+      "com.handicappin.premium.yearly",
+    ]);
+    assert.equal(mapped.entitlements.active["premium"]?.isActive, true);
+    assert.equal(
+      mapped.managementURL,
+      "https://apps.apple.com/account/subscriptions",
+    );
+  });
+
+  it("maps empty entitlements and null managementURL", () => {
+    const mapped = mapRcCustomerInfo({
+      originalAppUserId: "user-123",
+      activeSubscriptions: [],
+      entitlements: { active: {} },
+      managementURL: null,
+    });
+    assert.deepEqual(mapped.activeSubscriptions, []);
+    assert.deepEqual(mapped.entitlements.active, {});
+    assert.equal(mapped.managementURL, null);
+  });
+});

--- a/apps/web/app/api/webhooks/revenuecat/route.ts
+++ b/apps/web/app/api/webhooks/revenuecat/route.ts
@@ -86,12 +86,10 @@ async function recordEvent(params: {
 
 async function recordFailure(event: RcEvent, userId: string | null, message: string): Promise<void> {
   try {
-    const existing = await db
-      .select()
-      .from(webhookEvents)
-      .where(eq(webhookEvents.eventId, event.id))
-      .limit(1);
-    const retryCount = existing.length > 0 ? (existing[0].retryCount || 0) + 1 : 1;
+    // Pure upsert: a brand-new row starts at retryCount 1; a conflicting
+    // (already-seen) row gets its count incremented by the SQL expression in
+    // onConflictDoUpdate below. The previous pre-read to compute retryCount
+    // was dead — its value never reached the conflict path.
     await db
       .insert(webhookEvents)
       .values({
@@ -99,7 +97,7 @@ async function recordFailure(event: RcEvent, userId: string | null, message: str
         eventType: `revenuecat.${event.type}`,
         status: "failed",
         errorMessage: message,
-        retryCount,
+        retryCount: 1,
         userId,
         provider: PROVIDER,
         eventTimeMs: null,

--- a/apps/web/app/api/webhooks/revenuecat/route.ts
+++ b/apps/web/app/api/webhooks/revenuecat/route.ts
@@ -1,0 +1,386 @@
+/**
+ * RevenueCat webhook — Apple billing events into the SAME entitlement
+ * projection the Stripe webhook feeds (handoff DoD #3).
+ *
+ * Mirrors apps/web/app/api/stripe/webhook/route.ts in structure and
+ * security posture: rate limit → auth → trust-boundary parse →
+ * idempotency (webhook_events) → per-provider out-of-order guard →
+ * applyBillingEvent (THE merge chokepoint) → projection write with
+ * billing_version bump → success/failure recording + admin alerts.
+ *
+ * Auth: RevenueCat sends a configured value in the Authorization header on
+ * every request. Compared timing-safe against REVENUECAT_WEBHOOK_AUTH_TOKEN;
+ * absent config fails closed in production and open (with a warning) in dev.
+ */
+import { createHash, timingSafeEqual } from "crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { and, desc, eq, isNotNull, sql } from "drizzle-orm";
+import { db } from "@/db";
+import { profile, webhookEvents } from "@/db/schema";
+import { env } from "@/env";
+import { sendDoubleContractAlert, sendTransferAlert } from "@/lib/admin-alerts";
+import { webhookRateLimit, getIdentifier } from "@/lib/rate-limit";
+import { mapRevenueCatEvent } from "@/lib/revenuecat/map-event";
+import { rcWebhookPayloadSchema, type RcEvent } from "@/lib/revenuecat/schema";
+import {
+  logWebhookReceived,
+  logWebhookSuccess,
+  logWebhookError,
+  logWebhookInfo,
+  logWebhookWarning,
+} from "@/lib/webhook-logger";
+import { logger } from "@/lib/logging";
+import {
+  applyBillingEvent,
+  type BillingProjection,
+  type CurrentBillingState,
+} from "@/utils/billing/apply-billing-event";
+
+const PROVIDER = "apple" as const;
+
+function timingSafeStringEqual(a: string, b: string): boolean {
+  // Hash both sides so length differences don't leak through timingSafeEqual.
+  const ha = createHash("sha256").update(a).digest();
+  const hb = createHash("sha256").update(b).digest();
+  return timingSafeEqual(ha, hb);
+}
+
+/**
+ * 200-with-context for events we acknowledge without projecting. RevenueCat
+ * retries any non-200 up to 5 times — "not relevant to us" must be a 200.
+ */
+function acknowledged(body: Record<string, unknown>): NextResponse {
+  return NextResponse.json({ received: true, ...body }, { status: 200 });
+}
+
+async function recordEvent(params: {
+  event: RcEvent;
+  userId: string | null;
+  /** Advances the ordering cursor — only for EVALUATED entitlement events. */
+  advanceCursor: boolean;
+  note?: string;
+}): Promise<void> {
+  try {
+    await db
+      .insert(webhookEvents)
+      .values({
+        eventId: params.event.id,
+        eventType: `revenuecat.${params.event.type}`,
+        status: "success",
+        userId: params.userId,
+        provider: PROVIDER,
+        eventTimeMs: params.advanceCursor
+          ? params.event.event_timestamp_ms
+          : null,
+        errorMessage: params.note ?? null,
+      })
+      .onConflictDoNothing();
+  } catch (recordError) {
+    // Mirror the Stripe route: recording failure must not fail the webhook.
+    logWebhookError(
+      "Failed to record RevenueCat webhook event (event was processed)",
+      recordError,
+    );
+  }
+}
+
+async function recordFailure(event: RcEvent, userId: string | null, message: string): Promise<void> {
+  try {
+    const existing = await db
+      .select()
+      .from(webhookEvents)
+      .where(eq(webhookEvents.eventId, event.id))
+      .limit(1);
+    const retryCount = existing.length > 0 ? (existing[0].retryCount || 0) + 1 : 1;
+    await db
+      .insert(webhookEvents)
+      .values({
+        eventId: event.id,
+        eventType: `revenuecat.${event.type}`,
+        status: "failed",
+        errorMessage: message,
+        retryCount,
+        userId,
+        provider: PROVIDER,
+        eventTimeMs: null,
+      })
+      .onConflictDoUpdate({
+        target: webhookEvents.eventId,
+        set: {
+          retryCount: sql`${webhookEvents.retryCount} + 1`,
+          errorMessage: message,
+          processedAt: sql`CURRENT_TIMESTAMP`,
+        },
+      });
+  } catch (recordError) {
+    logWebhookError("Failed to record RevenueCat webhook failure", recordError);
+  }
+}
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export async function POST(request: NextRequest) {
+  let event: RcEvent | null = null;
+  let userId: string | null = null;
+
+  try {
+    // Rate limiting (IP-based, same limiter as the Stripe webhook).
+    const identifier = getIdentifier(request);
+    const { success, reset } = await webhookRateLimit.limit(identifier);
+    if (!success) {
+      const retryAfterSeconds = Math.ceil((reset - Date.now()) / 1000);
+      logger.warn(`[Rate Limit] RevenueCat webhook rate limited for ${identifier}`);
+      return NextResponse.json(
+        { error: "Rate limit exceeded", retryAfter: retryAfterSeconds },
+        { status: 429, headers: { "Retry-After": retryAfterSeconds.toString() } },
+      );
+    }
+
+    // Shared-secret Authorization header check.
+    const configuredToken = env.REVENUECAT_WEBHOOK_AUTH_TOKEN;
+    const authHeader = request.headers.get("authorization");
+    if (configuredToken) {
+      if (!authHeader || !timingSafeStringEqual(authHeader, configuredToken)) {
+        logWebhookWarning("RevenueCat webhook rejected: bad Authorization header");
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+      }
+    } else if (env.NODE_ENV === "production") {
+      // Fail closed: an unauthenticated billing webhook must not run in prod.
+      logWebhookError(
+        "REVENUECAT_WEBHOOK_AUTH_TOKEN is not configured in production - rejecting",
+      );
+      return NextResponse.json({ error: "Webhook not configured" }, { status: 503 });
+    } else {
+      logWebhookWarning(
+        "RevenueCat webhook auth SKIPPED (REVENUECAT_WEBHOOK_AUTH_TOKEN unset, non-production)",
+      );
+    }
+
+    // Trust-boundary parse.
+    let rawBody: unknown;
+    try {
+      rawBody = await request.json();
+    } catch {
+      return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+    }
+    const parsed = rcWebhookPayloadSchema.safeParse(rawBody);
+    if (!parsed.success) {
+      logWebhookWarning("RevenueCat payload failed schema validation", {
+        issues: parsed.error.issues.slice(0, 5),
+      });
+      return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+    }
+    event = parsed.data.event;
+    logWebhookReceived(`revenuecat.${event.type}`);
+
+    // Idempotency: same event id already processed successfully → no-op 200.
+    const existingEvent = await db
+      .select()
+      .from(webhookEvents)
+      .where(eq(webhookEvents.eventId, event.id))
+      .limit(1);
+    if (existingEvent.length > 0 && existingEvent[0].status === "success") {
+      logWebhookInfo(
+        `Duplicate RevenueCat event ${event.id} (${event.type}) - already processed at ${existingEvent[0].processedAt}`,
+      );
+      return acknowledged({
+        duplicate: true,
+        originalProcessedAt: existingEvent[0].processedAt,
+      });
+    }
+
+    // TRANSFER carries no app_user_id — alert-only path (D-status-mapping).
+    if (event.type === "TRANSFER") {
+      const transferredTo = event.transferred_to ?? [];
+      const transferredFrom = event.transferred_from ?? [];
+      await sendTransferAlert({
+        eventId: event.id,
+        transferredFrom,
+        transferredTo,
+      });
+      const candidate = transferredTo.find((id) => UUID_RE.test(id)) ?? null;
+      await recordEvent({
+        event,
+        userId: candidate,
+        advanceCursor: false,
+        note: `transfer: from=[${transferredFrom.join(",")}] to=[${transferredTo.join(",")}] (no entitlement write)`,
+      });
+      return acknowledged({ transfer: true, alerted: true });
+    }
+
+    // Resolve the subject user. app_user_id IS the Supabase user id
+    // (D-rc-scope: Purchases.logIn(supabaseUserId) after auth); RevenueCat
+    // anonymous ids ($RCAnonymousID:...) cannot map to a profile → skip.
+    const appUserId = event.app_user_id ?? null;
+    if (!appUserId || !UUID_RE.test(appUserId)) {
+      logWebhookInfo(
+        `Skipping RevenueCat event ${event.id} (${event.type}) - app_user_id is not a Supabase user id`,
+      );
+      await recordEvent({
+        event,
+        userId: null,
+        advanceCursor: false,
+        note: "skip: app_user_id not a supabase uuid",
+      });
+      return acknowledged({ skipped: "unrecognized-app-user-id" });
+    }
+
+    const profileRows = await db
+      .select({
+        id: profile.id,
+        planSelected: profile.planSelected,
+        subscriptionStatus: profile.subscriptionStatus,
+        currentPeriodEnd: profile.currentPeriodEnd,
+        cancelAtPeriodEnd: profile.cancelAtPeriodEnd,
+        billingProvider: profile.billingProvider,
+      })
+      .from(profile)
+      .where(eq(profile.id, appUserId))
+      .limit(1);
+
+    if (profileRows.length === 0) {
+      logWebhookWarning(
+        `RevenueCat event ${event.id} references unknown user ${appUserId} - skipping`,
+      );
+      await recordEvent({
+        event,
+        userId: null,
+        advanceCursor: false,
+        note: "skip: no profile for app_user_id",
+      });
+      return acknowledged({ skipped: "unknown-user" });
+    }
+    userId = profileRows[0].id;
+
+    const projection: BillingProjection = {
+      provider: profileRows[0].billingProvider,
+      plan: profileRows[0].planSelected,
+      status: profileRows[0].subscriptionStatus,
+      currentPeriodEnd: profileRows[0].currentPeriodEnd,
+      cancelAtPeriodEnd: profileRows[0].cancelAtPeriodEnd,
+    };
+
+    // Map the RC event into a normalized fact (or a skip).
+    const mapped = mapRevenueCatEvent(event, projection);
+
+    if (mapped.kind === "skip") {
+      logWebhookInfo(
+        `RevenueCat event ${event.id} (${event.type}) acknowledged without projection: ${mapped.reason}`,
+      );
+      await recordEvent({
+        event,
+        userId,
+        advanceCursor: false,
+        note: `skip: ${mapped.reason}`,
+      });
+      return acknowledged({ skipped: mapped.reason });
+    }
+    if (mapped.kind === "transfer") {
+      // Unreachable (handled above) — kept for exhaustiveness.
+      return acknowledged({ transfer: true });
+    }
+
+    // Per-provider ordering cursor: the latest successfully EVALUATED apple
+    // event for this user (D23 — webhook_events carries the cursor).
+    const cursorRows = await db
+      .select({
+        eventId: webhookEvents.eventId,
+        eventTimeMs: webhookEvents.eventTimeMs,
+      })
+      .from(webhookEvents)
+      .where(
+        and(
+          eq(webhookEvents.userId, userId),
+          eq(webhookEvents.provider, PROVIDER),
+          eq(webhookEvents.status, "success"),
+          isNotNull(webhookEvents.eventTimeMs),
+        ),
+      )
+      .orderBy(desc(webhookEvents.eventTimeMs))
+      .limit(1);
+
+    const current: CurrentBillingState = {
+      projection,
+      lastApplied:
+        cursorRows.length > 0 && cursorRows[0].eventTimeMs !== null
+          ? {
+              eventTimeMs: cursorRows[0].eventTimeMs,
+              eventId: cursorRows[0].eventId,
+            }
+          : null,
+    };
+
+    // THE merge chokepoint.
+    const decision = applyBillingEvent(current, mapped.fact);
+
+    if (decision.alert) {
+      await sendDoubleContractAlert(userId, decision.alert);
+    }
+
+    if (decision.action === "ignore" && decision.reason === "stale-out-of-order") {
+      logWebhookInfo(
+        `RevenueCat event ${event.id} (${event.type}) is older than the applied ${PROVIDER} cursor - ignored`,
+      );
+      // Deliberately NOT advancing the cursor (the event is older than it).
+      await recordEvent({
+        event,
+        userId,
+        advanceCursor: false,
+        note: "ignored: stale-out-of-order",
+      });
+      return acknowledged({ stale: true });
+    }
+
+    if (decision.changed) {
+      await db
+        .update(profile)
+        .set({
+          planSelected: decision.projection.plan,
+          planSelectedAt: new Date(),
+          subscriptionStatus: decision.projection.status,
+          currentPeriodEnd: decision.projection.currentPeriodEnd,
+          cancelAtPeriodEnd: decision.projection.cancelAtPeriodEnd,
+          billingProvider: decision.projection.provider,
+          billingVersion: sql`billing_version + 1`,
+        })
+        .where(eq(profile.id, userId));
+      logWebhookSuccess(
+        `RevenueCat ${event.type} applied for user ${userId}: plan=${decision.projection.plan} status=${decision.projection.status} provider=${decision.projection.provider} (${decision.reason})`,
+      );
+    } else {
+      logWebhookInfo(
+        `RevenueCat ${event.type} for user ${userId} produced no projection change (${decision.reason})`,
+      );
+    }
+
+    await recordEvent({
+      event,
+      userId,
+      advanceCursor: true,
+      note: decision.alert
+        ? `double_contract: kept ${decision.alert.keptProvider} (${decision.reason})`
+        : decision.action === "ignore"
+          ? `ignored: ${decision.reason}`
+          : undefined,
+    });
+
+    return acknowledged({
+      applied: decision.action === "apply",
+      changed: decision.changed,
+      reason: decision.reason,
+      ...(decision.alert ? { doubleContract: true } : {}),
+    });
+  } catch (error) {
+    logWebhookError("RevenueCat webhook handler failed", error);
+    if (event?.id) {
+      await recordFailure(
+        event,
+        userId,
+        error instanceof Error ? error.message : "Unknown error",
+      );
+    }
+    // Non-200 → RevenueCat retries (5/10/20/40/80 min).
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/apps/web/app/api/webhooks/revenuecat/route.ts
+++ b/apps/web/app/api/webhooks/revenuecat/route.ts
@@ -234,6 +234,8 @@ export async function POST(request: NextRequest) {
         currentPeriodEnd: profile.currentPeriodEnd,
         cancelAtPeriodEnd: profile.cancelAtPeriodEnd,
         billingProvider: profile.billingProvider,
+        // Captured for the optimistic-lock predicate on the final write.
+        billingVersion: profile.billingVersion,
       })
       .from(profile)
       .where(eq(profile.id, appUserId))
@@ -252,6 +254,7 @@ export async function POST(request: NextRequest) {
       return acknowledged({ skipped: "unknown-user" });
     }
     userId = profileRows[0].id;
+    const billingVersionAtRead = profileRows[0].billingVersion;
 
     const projection: BillingProjection = {
       provider: profileRows[0].billingProvider,
@@ -333,7 +336,13 @@ export async function POST(request: NextRequest) {
     }
 
     if (decision.changed) {
-      await db
+      // Optimistic concurrency: the write only lands if billing_version is
+      // still what we read. Every write path (this route + the Stripe
+      // handlers) bumps the version, so a concurrent webhook that already
+      // wrote will make this predicate miss — preventing a stale event from
+      // silently clobbering a higher entitlement past applyBillingEvent's
+      // precedence logic.
+      const updated = await db
         .update(profile)
         .set({
           planSelected: decision.projection.plan,
@@ -344,7 +353,26 @@ export async function POST(request: NextRequest) {
           billingProvider: decision.projection.provider,
           billingVersion: sql`billing_version + 1`,
         })
-        .where(eq(profile.id, userId));
+        .where(
+          and(
+            eq(profile.id, userId),
+            eq(profile.billingVersion, billingVersionAtRead),
+          ),
+        )
+        .returning({ id: profile.id });
+
+      if (updated.length === 0) {
+        // Lost the race. Do NOT record the event (no success/failure row) so
+        // RevenueCat's redelivery re-runs read→decide→write against the
+        // now-committed state and converges. Non-2xx triggers that retry.
+        logWebhookWarning(
+          `RevenueCat ${event.type} for user ${userId} hit a concurrent billing update (billing_version moved from ${billingVersionAtRead}) - asking RevenueCat to retry`,
+        );
+        return NextResponse.json(
+          { error: "Concurrent billing update, retry" },
+          { status: 409 },
+        );
+      }
       logWebhookSuccess(
         `RevenueCat ${event.type} applied for user ${userId}: plan=${decision.projection.plan} status=${decision.projection.status} provider=${decision.projection.provider} (${decision.reason})`,
       );

--- a/apps/web/components/dashboard/dashboard.stories.tsx
+++ b/apps/web/components/dashboard/dashboard.stories.tsx
@@ -18,6 +18,7 @@ const profile: Tables<"profile"> = {
   plan_selected: null,
   plan_selected_at: null,
   subscription_status: null,
+  billing_provider: null,
   verified: true,
 };
 

--- a/apps/web/components/profile/tabbed-profile-page.stories.tsx
+++ b/apps/web/components/profile/tabbed-profile-page.stories.tsx
@@ -41,6 +41,7 @@ const profile: Tables<"profile"> = {
   current_period_end: 1735689600,
   cancel_at_period_end: false,
   billing_version: 1,
+  billing_provider: "stripe",
 };
 
 const access: FeatureAccess = {

--- a/apps/web/components/scorecard/golf-scorecard.stories.tsx
+++ b/apps/web/components/scorecard/golf-scorecard.stories.tsx
@@ -18,6 +18,7 @@ const profile: Tables<"profile"> = {
   plan_selected: null,
   plan_selected_at: null,
   subscription_status: null,
+  billing_provider: null,
 };
 
 const premiumAccess: FeatureAccess = {

--- a/apps/web/db/schema.ts
+++ b/apps/web/db/schema.ts
@@ -63,6 +63,9 @@ export const profile = pgTable(
       "btree",
       table.email.asc().nullsLast().op("text_ops")
     ),
+    // Mirrors 20260612080537_add_billing_provider.sql — declared here so
+    // drizzle-kit generate stays in sync and won't try to drop it.
+    index("idx_profile_billing_provider").on(table.billingProvider),
     pgPolicy("Users can view their own profile", {
       as: "permissive",
       for: "select",
@@ -453,6 +456,12 @@ export const webhookEvents = pgTable(
     index("idx_webhook_events_event_type").on(table.eventType),
     index("idx_webhook_events_user_id").on(table.userId),
     index("idx_webhook_events_processed_at").on(table.processedAt),
+    // Per-provider ordering cursor (partial: success rows only). Mirrors
+    // 20260612080537_add_billing_provider.sql so drizzle-kit generate stays
+    // in sync.
+    index("idx_webhook_events_provider_cursor")
+      .on(table.userId, table.provider, table.eventTimeMs)
+      .where(sql`status = 'success'`),
     foreignKey({
       columns: [table.userId],
       foreignColumns: [profile.id],

--- a/apps/web/db/schema.ts
+++ b/apps/web/db/schema.ts
@@ -18,6 +18,7 @@ import { sql } from "drizzle-orm";
 import { createSelectSchema } from "drizzle-zod";
 import type { InferSelectModel } from "drizzle-orm";
 import type { PlanType, SubscriptionStatus } from "@/lib/stripe-types";
+import type { BillingProviderId } from "@handicappin/billing-core";
 
 const authSchema = pgSchema("auth");
 
@@ -47,6 +48,8 @@ export const profile = pgTable(
     currentPeriodEnd: bigint("current_period_end", { mode: "number" }), // Y2038-proof unix timestamp
     cancelAtPeriodEnd: boolean("cancel_at_period_end").default(false).notNull(),
     billingVersion: integer("billing_version").default(1).notNull(),
+    // Which provider bills the CURRENT contract (D-arch): webhook/service writes only
+    billingProvider: text("billing_provider").$type<BillingProviderId | null>(),
   },
   (table) => [
     foreignKey({
@@ -79,6 +82,7 @@ export const profile = pgTable(
         AND current_period_end IS NOT DISTINCT FROM (SELECT current_period_end FROM profile WHERE id = auth.uid())
         AND cancel_at_period_end IS NOT DISTINCT FROM (SELECT cancel_at_period_end FROM profile WHERE id = auth.uid())
         AND billing_version IS NOT DISTINCT FROM (SELECT billing_version FROM profile WHERE id = auth.uid())
+        AND billing_provider IS NOT DISTINCT FROM (SELECT billing_provider FROM profile WHERE id = auth.uid())
       )`,
     }),
     pgPolicy("Users can insert their own profile", {
@@ -440,6 +444,10 @@ export const webhookEvents = pgTable(
     errorMessage: text("error_message"),
     retryCount: integer("retry_count").default(0).notNull(),
     userId: uuid("user_id"),
+    // Per-provider out-of-order guard: which provider sent the event and the
+    // provider's own event timestamp. NULL on legacy Stripe rows.
+    provider: text("provider").$type<BillingProviderId | null>(),
+    eventTimeMs: bigint("event_time_ms", { mode: "number" }),
   },
   (table) => [
     index("idx_webhook_events_event_type").on(table.eventType),

--- a/apps/web/env.ts
+++ b/apps/web/env.ts
@@ -17,6 +17,12 @@ export const env = createEnv({
     STRIPE_UNLIMITED_PRICE_ID: z.string(),
     STRIPE_UNLIMITED_LIFETIME_PRICE_ID: z.string(),
 
+    // RevenueCat (Apple billing). Optional in dev: the webhook fails closed
+    // in production when the auth token is unset; the reconcile script
+    // skips Apple-side checks without the API key.
+    REVENUECAT_WEBHOOK_AUTH_TOKEN: z.string().optional(),
+    REVENUECAT_API_KEY: z.string().optional(),
+
     KV_URL: z.url(),
     KV_REST_API_URL: z.url(),
     KV_REST_API_TOKEN: z.string(),
@@ -66,6 +72,8 @@ export const env = createEnv({
     STRIPE_UNLIMITED_PRICE_ID: process.env.STRIPE_UNLIMITED_PRICE_ID,
     STRIPE_UNLIMITED_LIFETIME_PRICE_ID:
       process.env.STRIPE_UNLIMITED_LIFETIME_PRICE_ID,
+    REVENUECAT_WEBHOOK_AUTH_TOKEN: process.env.REVENUECAT_WEBHOOK_AUTH_TOKEN,
+    REVENUECAT_API_KEY: process.env.REVENUECAT_API_KEY,
     KV_URL: process.env.KV_URL,
     KV_REST_API_URL: process.env.KV_REST_API_URL,
     KV_REST_API_TOKEN: process.env.KV_REST_API_TOKEN,

--- a/apps/web/lib/admin-alerts.ts
+++ b/apps/web/lib/admin-alerts.ts
@@ -6,6 +6,7 @@
 import * as Sentry from "@sentry/nextjs";
 import { captureSentryError } from "@/lib/sentry-utils";
 import { logger } from "@/lib/logging";
+import type { DoubleContractAlert } from "@/utils/billing/apply-billing-event";
 
 export interface WebhookFailureAlert {
   userId: string;
@@ -68,4 +69,77 @@ export async function sendAdminWebhookAlert(failure: WebhookFailureAlert): Promi
   );
 
   logger.info("Critical webhook failure sent to Sentry", { eventId: failure.eventId });
+}
+
+/**
+ * Double-contract alert (decision ledger D-precedence): a user appears to
+ * hold ACTIVE contracts with BOTH providers. We keep max entitlement and
+ * never auto-cancel the other side — a human resolves the double billing.
+ */
+export async function sendDoubleContractAlert(
+  userId: string,
+  alert: DoubleContractAlert,
+): Promise<void> {
+  logger.error("BILLING DOUBLE-CONTRACT - ADMIN ALERT", {
+    userId,
+    ...alert,
+  });
+
+  captureSentryError(
+    new Error(
+      `Billing double-contract for user: ${alert.currentProvider}(${alert.currentPlan}) vs incoming ${alert.incomingProvider}(${alert.incomingPlan}) — kept ${alert.keptProvider}`,
+    ),
+    {
+      level: "fatal",
+      userId,
+      eventType: "billing.double_contract",
+      eventId: alert.eventId,
+      tags: {
+        billing_alert: "double_contract",
+        kept_provider: alert.keptProvider,
+      },
+      extra: {
+        remediation: {
+          action:
+            "User is paying two providers. Refund/cancel ONE manually — never auto-cancel.",
+          currentProvider: alert.currentProvider,
+          incomingProvider: alert.incomingProvider,
+        },
+      },
+    },
+  );
+}
+
+/**
+ * RevenueCat TRANSFER alert (D-status-mapping: no entitlement write).
+ * Entitlements moved between app user ids — needs a human eye because our
+ * app_user_id IS the Supabase user id and transfers can mean account
+ * switching or family-share edge cases.
+ */
+export async function sendTransferAlert(params: {
+  eventId: string;
+  transferredFrom: string[];
+  transferredTo: string[];
+}): Promise<void> {
+  logger.error("BILLING TRANSFER EVENT - ADMIN ALERT", params);
+
+  captureSentryError(
+    new Error(
+      `RevenueCat TRANSFER: entitlements moved between app users (no automatic write performed)`,
+    ),
+    {
+      level: "error",
+      eventType: "billing.transfer",
+      eventId: params.eventId,
+      tags: { billing_alert: "transfer" },
+      extra: {
+        transferredFrom: params.transferredFrom,
+        transferredTo: params.transferredTo,
+        remediation: {
+          action:
+            "Verify which Supabase users are involved and reconcile entitlement manually if needed.",
+        },
+      },
+    },
+  );
 }

--- a/apps/web/lib/rate-limit.ts
+++ b/apps/web/lib/rate-limit.ts
@@ -191,13 +191,17 @@ export function getIdentifier(request: Request, userId?: string): string {
     return `user:${userId}`;
   }
 
-  // Fall back to IP address for unauthenticated requests
+  // Fall back to IP address for unauthenticated requests.
+  // Prefer x-real-ip: on Vercel the platform sets it to the true client IP and
+  // overwrites any client-supplied value. x-forwarded-for is NOT trustworthy
+  // for this — a client can prepend an arbitrary IP and Vercel appends the
+  // real one on the RIGHT, so the leftmost (client) entry is attacker-chosen
+  // and would let one client mint unlimited rate-limit buckets.
+  const realIp = request.headers.get('x-real-ip')?.trim();
   const forwarded = request.headers.get('x-forwarded-for');
-  const realIp = request.headers.get('x-real-ip');
-
-  // x-forwarded-for can contain multiple IPs (client, proxy1, proxy2)
-  // Take the first one (original client IP)
-  const ip = forwarded?.split(',')[0]?.trim() || realIp || 'unknown';
+  // Fallback only (non-Vercel/local): take the LAST hop, the closest proxy.
+  const forwardedLast = forwarded?.split(',').pop()?.trim();
+  const ip = realIp || forwardedLast || 'unknown';
 
   return `ip:${ip}`;
 }

--- a/apps/web/lib/revenuecat/map-event.ts
+++ b/apps/web/lib/revenuecat/map-event.ts
@@ -1,0 +1,189 @@
+/**
+ * RevenueCat event → normalized BillingFact (decision ledger D-status-mapping).
+ *
+ * Pure: takes the parsed RC event plus the user's current projection (some RC
+ * events carry partial information — CANCELLATION says only "auto-renew off",
+ * so the rest of the fact is overlaid from the same-provider contract state,
+ * exactly like Stripe's subscription.updated arrives with full state).
+ *
+ * | RC event              | Fact                                              |
+ * |-----------------------|---------------------------------------------------|
+ * | INITIAL_PURCHASE      | plan from SKU, active (trialing on TRIAL period)  |
+ * | RENEWAL               | same — also resolves deferred downgrades          |
+ * | PRODUCT_CHANGE        | NO fact (informational; RENEWAL carries product)  |
+ * | CANCELLATION          | cancel_at_period_end: true, rest from current     |
+ * | UNCANCELLATION        | cancel_at_period_end: false                       |
+ * | BILLING_ISSUE         | past_due (denies immediately; no grace nuance)    |
+ * | EXPIRATION            | free/canceled (mirror of subscription.deleted)    |
+ * | NON_RENEWING_PURCHASE | lifetime SKU → lifetime (payment_intent mirror)   |
+ * | TRANSFER              | NO fact — admin alert only                        |
+ */
+import { appleSkuToPlan } from "@handicappin/billing-core";
+import type {
+  BillingFact,
+  BillingProjection,
+} from "@/utils/billing/apply-billing-event";
+import type { RcEvent } from "./schema";
+
+export type RcMapResult =
+  | { kind: "fact"; fact: BillingFact }
+  | { kind: "transfer" }
+  | { kind: "skip"; reason: RcSkipReason };
+
+export type RcSkipReason =
+  | "test-event"
+  | "unhandled-type"
+  | "product-change-informational"
+  | "unsupported-store"
+  | "unknown-product";
+
+function msToSeconds(ms: number | null | undefined): number | null {
+  return typeof ms === "number" ? Math.floor(ms / 1000) : null;
+}
+
+/**
+ * The same-provider contract state to overlay partial events onto — only
+ * meaningful while the projection is actually attributed to Apple.
+ */
+function appleBase(projection: BillingProjection): BillingProjection | null {
+  return projection.provider === "apple" ? projection : null;
+}
+
+export function mapRevenueCatEvent(
+  event: RcEvent,
+  projection: BillingProjection,
+): RcMapResult {
+  if (event.type === "TEST") {
+    return { kind: "skip", reason: "test-event" };
+  }
+
+  if (event.type === "TRANSFER") {
+    // D-status-mapping: no entitlement write, admin alert only.
+    return { kind: "transfer" };
+  }
+
+  if (event.type === "PRODUCT_CHANGE") {
+    // RC sends PRODUCT_CHANGE alongside (upgrade) or ahead of (downgrade)
+    // the RENEWAL that actually carries the new product. Writing here would
+    // either double-apply or grant the downgrade early — and advancing the
+    // ordering cursor here could suppress that very RENEWAL. Skip (D24).
+    return { kind: "skip", reason: "product-change-informational" };
+  }
+
+  // D-rc-scope: RevenueCat is Apple-side plumbing only. RC's Stripe/Web
+  // Billing integrations are not used; PROMOTIONAL/PLAY_STORE etc. have no
+  // mapping into this projection.
+  if (event.store !== undefined && event.store !== "APP_STORE") {
+    return { kind: "skip", reason: "unsupported-store" };
+  }
+
+  const base = appleBase(projection);
+  const skuPlan = event.product_id ? appleSkuToPlan(event.product_id) : null;
+  const periodEndSeconds = msToSeconds(event.expiration_at_ms);
+  const common = {
+    provider: "apple" as const,
+    eventTimeMs: event.event_timestamp_ms,
+    eventId: event.id,
+  };
+
+  switch (event.type) {
+    case "INITIAL_PURCHASE":
+    case "RENEWAL": {
+      if (!skuPlan) return { kind: "skip", reason: "unknown-product" };
+      return {
+        kind: "fact",
+        fact: {
+          ...common,
+          plan: skuPlan,
+          status: event.period_type === "TRIAL" ? "trialing" : "active",
+          currentPeriodEnd: periodEndSeconds,
+          cancelAtPeriodEnd: false,
+        },
+      };
+    }
+
+    case "NON_RENEWING_PURCHASE": {
+      // Only the lifetime SKU exists as a non-renewing product (D-products).
+      if (skuPlan !== "lifetime") {
+        return { kind: "skip", reason: "unknown-product" };
+      }
+      return {
+        kind: "fact",
+        fact: {
+          ...common,
+          plan: "lifetime",
+          status: "active",
+          currentPeriodEnd: null,
+          cancelAtPeriodEnd: false,
+        },
+      };
+    }
+
+    case "CANCELLATION": {
+      const plan = skuPlan ?? base?.plan ?? null;
+      if (!plan) return { kind: "skip", reason: "unknown-product" };
+      return {
+        kind: "fact",
+        fact: {
+          ...common,
+          plan,
+          // Auto-renew off says nothing about the CURRENT status — keep it
+          // (a past_due contract being cancelled must stay past_due).
+          status: base?.status ?? "active",
+          currentPeriodEnd: periodEndSeconds ?? base?.currentPeriodEnd ?? null,
+          cancelAtPeriodEnd: true,
+        },
+      };
+    }
+
+    case "UNCANCELLATION": {
+      const plan = skuPlan ?? base?.plan ?? null;
+      if (!plan) return { kind: "skip", reason: "unknown-product" };
+      return {
+        kind: "fact",
+        fact: {
+          ...common,
+          plan,
+          status: base?.status ?? "active",
+          currentPeriodEnd: periodEndSeconds ?? base?.currentPeriodEnd ?? null,
+          cancelAtPeriodEnd: false,
+        },
+      };
+    }
+
+    case "BILLING_ISSUE": {
+      const plan = skuPlan ?? base?.plan ?? null;
+      if (!plan) return { kind: "skip", reason: "unknown-product" };
+      return {
+        kind: "fact",
+        fact: {
+          ...common,
+          plan,
+          // D-status-mapping: deny immediately, same as Stripe past_due.
+          // The store grace period nuance is intentionally NOT ported.
+          status: "past_due",
+          currentPeriodEnd: periodEndSeconds ?? base?.currentPeriodEnd ?? null,
+          cancelAtPeriodEnd: base?.cancelAtPeriodEnd ?? false,
+        },
+      };
+    }
+
+    case "EXPIRATION": {
+      if (!skuPlan) return { kind: "skip", reason: "unknown-product" };
+      // Mirror of customer.subscription.deleted: revert to free tier.
+      return {
+        kind: "fact",
+        fact: {
+          ...common,
+          plan: "free",
+          status: "canceled",
+          currentPeriodEnd: null,
+          cancelAtPeriodEnd: false,
+        },
+      };
+    }
+
+    default:
+      return { kind: "skip", reason: "unhandled-type" };
+  }
+}

--- a/apps/web/lib/revenuecat/map-event.ts
+++ b/apps/web/lib/revenuecat/map-event.ts
@@ -120,6 +120,11 @@ export function mapRevenueCatEvent(
     }
 
     case "CANCELLATION": {
+      // When CANCELLATION omits product_id (RC commonly does), plan falls back
+      // to the stored projection. If a PRODUCT_CHANGE is pending (write-free
+      // per D24), that projection is the PRE-change tier, so the recorded plan
+      // can be briefly stale. No access-control impact (status is unchanged)
+      // and it self-heals on the next RENEWAL, which is authoritative.
       const plan = skuPlan ?? base?.plan ?? null;
       if (!plan) return { kind: "skip", reason: "unknown-product" };
       return {
@@ -169,8 +174,13 @@ export function mapRevenueCatEvent(
     }
 
     case "EXPIRATION": {
-      if (!skuPlan) return { kind: "skip", reason: "unknown-product" };
       // Mirror of customer.subscription.deleted: revert to free tier.
+      // Deliberately does NOT require a resolvable product_id — expiration
+      // means "no Apple entitlement" regardless of which SKU expired, and
+      // skipping on a missing product_id would silently leave an expired
+      // user with paid access. Cross-provider safety is still preserved by
+      // applyBillingEvent (an apple→free fact can't clobber a live Stripe
+      // contract).
       return {
         kind: "fact",
         fact: {

--- a/apps/web/lib/revenuecat/schema.ts
+++ b/apps/web/lib/revenuecat/schema.ts
@@ -1,0 +1,61 @@
+/**
+ * Trust-boundary schema for RevenueCat webhook payloads.
+ *
+ * Shape source: RevenueCat's official webhook docs
+ * (https://www.revenuecat.com/docs/integrations/webhooks/event-types-and-fields,
+ * read 2026-06-12): `{ api_version, event }` with a flat event object whose
+ * optional fields vary by `type`. Loose-parsed — RevenueCat adds fields and
+ * event types over time and an unknown extra must never bounce the webhook.
+ */
+import { z } from "zod";
+
+/**
+ * Event types that carry an entitlement claim we project into the profile
+ * (decision ledger D-status-mapping).
+ */
+export const RC_ENTITLEMENT_EVENT_TYPES = [
+  "INITIAL_PURCHASE",
+  "RENEWAL",
+  "CANCELLATION",
+  "UNCANCELLATION",
+  "BILLING_ISSUE",
+  "EXPIRATION",
+  "NON_RENEWING_PURCHASE",
+] as const;
+
+export type RcEntitlementEventType =
+  (typeof RC_ENTITLEMENT_EVENT_TYPES)[number];
+
+export const rcEventSchema = z
+  .object({
+    id: z.string().min(1),
+    type: z.string().min(1),
+    event_timestamp_ms: z.number().int().positive(),
+    app_user_id: z.string().min(1).optional(),
+    original_app_user_id: z.string().optional(),
+    aliases: z.array(z.string()).optional(),
+    product_id: z.string().optional(),
+    new_product_id: z.string().nullable().optional(),
+    entitlement_ids: z.array(z.string()).nullable().optional(),
+    period_type: z.string().optional(),
+    purchased_at_ms: z.number().int().nullable().optional(),
+    expiration_at_ms: z.number().int().nullable().optional(),
+    store: z.string().optional(),
+    environment: z.string().optional(),
+    cancel_reason: z.string().nullable().optional(),
+    expiration_reason: z.string().nullable().optional(),
+    transferred_from: z.array(z.string()).nullable().optional(),
+    transferred_to: z.array(z.string()).nullable().optional(),
+  })
+  .loose();
+
+export type RcEvent = z.infer<typeof rcEventSchema>;
+
+export const rcWebhookPayloadSchema = z
+  .object({
+    api_version: z.string().optional(),
+    event: rcEventSchema,
+  })
+  .loose();
+
+export type RcWebhookPayload = z.infer<typeof rcWebhookPayloadSchema>;

--- a/apps/web/lib/stripe-webhook-handlers/checkout-handlers.ts
+++ b/apps/web/lib/stripe-webhook-handlers/checkout-handlers.ts
@@ -15,6 +15,8 @@ import {
 import { verifyCustomerOwnership } from "@/lib/stripe-security";
 import { verifyPaymentAmount, formatAmount } from "@/utils/billing/pricing";
 import { sendWelcomeEmail } from "@/lib/email-service";
+import type { BillingFact } from "@/utils/billing/apply-billing-event";
+import { guardedStripeProfileWrite } from "./profile-billing-write";
 import type { WebhookContext, WebhookResult } from "./types";
 
 /**
@@ -74,13 +76,13 @@ export async function handleCheckoutCompleted(
 
   // For subscription mode, handle subscription immediately to avoid race condition
   if (session.mode === "subscription") {
-    await handleSubscriptionCheckout(session, userId, expandedSession);
+    await handleSubscriptionCheckout(session, userId, expandedSession, ctx);
     return { success: true };
   }
 
   // For payment mode (lifetime), check payment status first
   if (session.mode === "payment") {
-    await handlePaymentCheckout(session, userId, customerId, expandedSession);
+    await handlePaymentCheckout(session, userId, customerId, expandedSession, ctx);
     return { success: true };
   }
 
@@ -90,7 +92,8 @@ export async function handleCheckoutCompleted(
 async function handleSubscriptionCheckout(
   session: Stripe.Checkout.Session,
   userId: string,
-  expandedSession: Stripe.Checkout.Session
+  expandedSession: Stripe.Checkout.Session,
+  ctx: WebhookContext
 ) {
   logSubscriptionEvent("Subscription checkout - updating plan immediately");
 
@@ -192,22 +195,48 @@ async function handleSubscriptionCheckout(
       session.customer_details?.email || session.customer_email;
     const isFirstTimeSubscription = oldPlan === "free";
 
-    // Update plan immediately (status fields updated by subscription.created event)
-    await db
-      .update(profile)
-      .set({
-        planSelected: plan,
-        planSelectedAt: new Date(),
-        billingVersion: sql`billing_version + 1`,
-      })
-      .where(eq(profile.id, userId));
+    // Update plan immediately (status fields updated by subscription.created
+    // event) — guarded: a fresh stripe checkout must not displace a higher
+    // apple-active contract or a lifetime entitlement.
+    const fact: BillingFact = {
+      provider: "stripe",
+      plan,
+      status: "active",
+      currentPeriodEnd: null, // unknown at checkout; subscription.created fills it
+      cancelAtPeriodEnd: false,
+      eventTimeMs: ctx.event.created * 1000,
+      eventId: ctx.eventId,
+    };
 
-    logWebhookSuccess(
-      `Updated plan_selected to '${plan}' for user: ${userId} at checkout (status will be updated by subscription.created)`
-    );
+    const { written } = await guardedStripeProfileWrite({
+      userId,
+      handler: "handleSubscriptionCheckout",
+      fact,
+      write: async () => {
+        await db
+          .update(profile)
+          .set({
+            planSelected: plan,
+            planSelectedAt: new Date(),
+            billingProvider: "stripe",
+            billingVersion: sql`billing_version + 1`,
+          })
+          .where(eq(profile.id, userId));
+      },
+    });
+
+    if (written) {
+      logWebhookSuccess(
+        `Updated plan_selected to '${plan}' for user: ${userId} at checkout (status will be updated by subscription.created)`
+      );
+    } else {
+      logWebhookInfo(
+        `Checkout plan write for user ${userId} blocked by precedence guard`
+      );
+    }
 
     // Send welcome email for first-time subscriptions
-    if (isFirstTimeSubscription && userEmail) {
+    if (written && isFirstTimeSubscription && userEmail) {
       await sendWelcomeEmailSafely(userEmail, plan, userId);
     }
   } catch (error) {
@@ -220,7 +249,8 @@ async function handlePaymentCheckout(
   session: Stripe.Checkout.Session,
   userId: string,
   customerId: string | undefined,
-  expandedSession: Stripe.Checkout.Session
+  expandedSession: Stripe.Checkout.Session,
+  ctx: WebhookContext
 ) {
   logPaymentEvent("Payment mode detected - checking payment status");
 
@@ -365,11 +395,11 @@ async function handlePaymentCheckout(
     });
 
     if (paymentStatus === "paid") {
-      await grantLifetimeAccess(session, userId, plan);
+      await grantLifetimeAccess(session, userId, plan, ctx);
     } else if (paymentStatus === "unpaid") {
       await storePendingPurchase(session, userId, priceId, plan);
     } else if (paymentStatus === "no_payment_required") {
-      await grantLifetimeAccess(session, userId, plan);
+      await grantLifetimeAccess(session, userId, plan, ctx);
     } else {
       logWebhookWarning(
         `Unknown payment status: ${paymentStatus} for session ${session.id}`
@@ -384,7 +414,8 @@ async function handlePaymentCheckout(
 async function grantLifetimeAccess(
   session: Stripe.Checkout.Session,
   userId: string,
-  plan: string
+  plan: string,
+  ctx: WebhookContext
 ) {
   logPaymentEvent(`Payment confirmed - granting ${plan} access to user ${userId}`);
 
@@ -401,19 +432,44 @@ async function grantLifetimeAccess(
   const isFirstTimePurchase = oldPlan === "free";
 
   try {
-    await db
-      .update(profile)
-      .set({
-        planSelected: plan as any,
-        planSelectedAt: new Date(),
-        subscriptionStatus: "active",
-        currentPeriodEnd: null,
-        cancelAtPeriodEnd: false,
-        billingVersion: sql`billing_version + 1`,
-      })
-      .where(eq(profile.id, userId));
+    const fact: BillingFact = {
+      provider: "stripe",
+      plan: plan as BillingFact["plan"],
+      status: "active",
+      currentPeriodEnd: null,
+      cancelAtPeriodEnd: false,
+      eventTimeMs: ctx.event.created * 1000,
+      eventId: ctx.eventId,
+    };
 
-    logWebhookSuccess(`Granted ${plan} access to user ${userId}`);
+    const { written } = await guardedStripeProfileWrite({
+      userId,
+      handler: "grantLifetimeAccess",
+      fact,
+      write: async () => {
+        await db
+          .update(profile)
+          .set({
+            planSelected: plan as any,
+            planSelectedAt: new Date(),
+            subscriptionStatus: "active",
+            currentPeriodEnd: null,
+            cancelAtPeriodEnd: false,
+            billingProvider: "stripe",
+            billingVersion: sql`billing_version + 1`,
+          })
+          .where(eq(profile.id, userId));
+      },
+    });
+
+    if (written) {
+      logWebhookSuccess(`Granted ${plan} access to user ${userId}`);
+    } else {
+      logWebhookInfo(
+        `Lifetime grant for user ${userId} blocked by precedence guard (already lifetime or higher contract)`
+      );
+      return;
+    }
   } catch (dbError) {
     logWebhookError("Error updating plan", dbError);
     throw dbError;

--- a/apps/web/lib/stripe-webhook-handlers/invoice-handlers.ts
+++ b/apps/web/lib/stripe-webhook-handlers/invoice-handlers.ts
@@ -12,6 +12,11 @@ import {
   logPaymentEvent,
 } from "@/lib/webhook-logger";
 import { verifyCustomerOwnership } from "@/lib/stripe-security";
+import type { BillingFact } from "@/utils/billing/apply-billing-event";
+import {
+  guardedStripeProfileWrite,
+  readBillingProjection,
+} from "./profile-billing-write";
 import type { WebhookContext, WebhookResult } from "./types";
 
 /**
@@ -91,18 +96,50 @@ export async function handleInvoicePaymentFailed(
       subscriptionId,
     });
 
-    // Update subscription status to past_due
-    await db
-      .update(profile)
-      .set({
-        subscriptionStatus: "past_due",
-        billingVersion: sql`billing_version + 1`,
-      })
-      .where(eq(profile.id, userId));
+    // Update subscription status to past_due — guarded: a stripe invoice
+    // failure must not mark an apple-billed contract (or a lifetime) past
+    // due. The fact reuses the projection's stripe contract fields since an
+    // invoice carries no plan/period of its own.
+    const projection = await readBillingProjection(userId);
+    const fact: BillingFact = {
+      provider: "stripe",
+      plan: projection?.provider === "stripe" ? projection.plan : null,
+      status: "past_due",
+      currentPeriodEnd:
+        projection?.provider === "stripe" ? projection.currentPeriodEnd : null,
+      cancelAtPeriodEnd:
+        projection?.provider === "stripe"
+          ? projection.cancelAtPeriodEnd
+          : false,
+      eventTimeMs: ctx.event.created * 1000,
+      eventId: ctx.eventId,
+    };
 
-    logWebhookSuccess(
-      `Updated subscription status to past_due for user ${userId}`
-    );
+    const { written } = await guardedStripeProfileWrite({
+      userId,
+      handler: "handleInvoicePaymentFailed",
+      fact,
+      write: async () => {
+        await db
+          .update(profile)
+          .set({
+            subscriptionStatus: "past_due",
+            billingProvider: "stripe",
+            billingVersion: sql`billing_version + 1`,
+          })
+          .where(eq(profile.id, userId));
+      },
+    });
+
+    if (written) {
+      logWebhookSuccess(
+        `Updated subscription status to past_due for user ${userId}`
+      );
+    } else {
+      logWebhookInfo(
+        `past_due write for user ${userId} blocked by precedence guard`
+      );
+    }
 
     // Log warning if this is the final attempt
     if (attemptCount >= 3) {

--- a/apps/web/lib/stripe-webhook-handlers/payment-intent-handlers.ts
+++ b/apps/web/lib/stripe-webhook-handlers/payment-intent-handlers.ts
@@ -11,6 +11,8 @@ import {
   logPaymentEvent,
 } from "@/lib/webhook-logger";
 import { sendWelcomeEmail } from "@/lib/email-service";
+import type { BillingFact } from "@/utils/billing/apply-billing-event";
+import { guardedStripeProfileWrite } from "./profile-billing-write";
 import type { WebhookContext, WebhookResult } from "./types";
 
 /**
@@ -84,29 +86,55 @@ export async function handlePaymentIntentSucceeded(
 
     const isFirstTimePurchase = oldPlan === "free";
 
+    let written = false;
     try {
-      await db
-        .update(profile)
-        .set({
-          planSelected: purchase.plan,
-          planSelectedAt: new Date(),
-          subscriptionStatus: "active",
-          currentPeriodEnd: null,
-          cancelAtPeriodEnd: false,
-          billingVersion: sql`billing_version + 1`,
-        })
-        .where(eq(profile.id, purchase.userId));
+      const fact: BillingFact = {
+        provider: "stripe",
+        plan: purchase.plan,
+        status: "active",
+        currentPeriodEnd: null,
+        cancelAtPeriodEnd: false,
+        eventTimeMs: ctx.event.created * 1000,
+        eventId: ctx.eventId,
+      };
 
-      logWebhookSuccess(
-        `Granted ${purchase.plan} access to user ${purchase.userId}`
-      );
+      const result = await guardedStripeProfileWrite({
+        userId: purchase.userId,
+        handler: "handlePaymentIntentSucceeded",
+        fact,
+        write: async () => {
+          await db
+            .update(profile)
+            .set({
+              planSelected: purchase.plan,
+              planSelectedAt: new Date(),
+              subscriptionStatus: "active",
+              currentPeriodEnd: null,
+              cancelAtPeriodEnd: false,
+              billingProvider: "stripe",
+              billingVersion: sql`billing_version + 1`,
+            })
+            .where(eq(profile.id, purchase.userId));
+        },
+      });
+      written = result.written;
+
+      if (written) {
+        logWebhookSuccess(
+          `Granted ${purchase.plan} access to user ${purchase.userId}`
+        );
+      } else {
+        logWebhookInfo(
+          `Lifetime grant for user ${purchase.userId} blocked by precedence guard`
+        );
+      }
     } catch (dbError) {
       logWebhookError("Error updating plan", dbError);
       throw dbError;
     }
 
     // Send welcome email for first-time purchases
-    if (isFirstTimePurchase && userEmail) {
+    if (written && isFirstTimePurchase && userEmail) {
       try {
         const dashboardUrl = `${process.env.NEXT_PUBLIC_APP_URL}/dashboard`;
 

--- a/apps/web/lib/stripe-webhook-handlers/profile-billing-write.ts
+++ b/apps/web/lib/stripe-webhook-handlers/profile-billing-write.ts
@@ -1,0 +1,108 @@
+/**
+ * Guarded profile billing writes for the STRIPE webhook handlers
+ * (handoff DoD #4): every final write is arbitrated by the same
+ * applyBillingEvent chokepoint the RevenueCat webhook uses, so Stripe can
+ * never overwrite a lifetime entitlement and never clobber an apple-active
+ * contract. Handlers keep their existing (sometimes partial) update
+ * payloads — the chokepoint decides WHETHER the write may happen, the
+ * handler still decides WHAT it writes, plus the billing_provider stamp.
+ *
+ * Stripe ordering semantics are deliberately unchanged: `lastApplied` is
+ * passed as null (no out-of-order enforcement), exactly as before this
+ * module existed.
+ */
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { profile } from "@/db/schema";
+import { sendDoubleContractAlert } from "@/lib/admin-alerts";
+import { logWebhookInfo, logWebhookWarning } from "@/lib/webhook-logger";
+import {
+  applyBillingEvent,
+  type ApplyDecision,
+  type BillingFact,
+  type BillingProjection,
+} from "@/utils/billing/apply-billing-event";
+
+export type StripeWriteVerdict =
+  | { allowed: true; decision: ApplyDecision }
+  | { allowed: false; decision: ApplyDecision; blockedBy: string };
+
+/**
+ * Pure arbitration: may this stripe fact write over the current projection?
+ * (Separated from I/O so the guard matrix is unit-testable.)
+ */
+export function decideStripeProfileWrite(
+  projection: BillingProjection,
+  fact: BillingFact,
+): StripeWriteVerdict {
+  const decision = applyBillingEvent(
+    { projection, lastApplied: null },
+    fact,
+  );
+  if (decision.action === "apply") {
+    return { allowed: true, decision };
+  }
+  return { allowed: false, decision, blockedBy: decision.reason };
+}
+
+export async function readBillingProjection(
+  userId: string,
+): Promise<BillingProjection | null> {
+  const rows = await db
+    .select({
+      planSelected: profile.planSelected,
+      subscriptionStatus: profile.subscriptionStatus,
+      currentPeriodEnd: profile.currentPeriodEnd,
+      cancelAtPeriodEnd: profile.cancelAtPeriodEnd,
+      billingProvider: profile.billingProvider,
+    })
+    .from(profile)
+    .where(eq(profile.id, userId))
+    .limit(1);
+  if (rows.length === 0) return null;
+  return {
+    provider: rows[0].billingProvider,
+    plan: rows[0].planSelected,
+    status: rows[0].subscriptionStatus,
+    currentPeriodEnd: rows[0].currentPeriodEnd,
+    cancelAtPeriodEnd: rows[0].cancelAtPeriodEnd,
+  };
+}
+
+/**
+ * Run the handler's profile update iff the precedence guards allow the
+ * stripe fact. Returns whether the write happened. On a blocked
+ * double-contract the admin alert fires here (kept provider = current).
+ */
+export async function guardedStripeProfileWrite(params: {
+  userId: string;
+  handler: string;
+  fact: BillingFact;
+  /** The handler's existing update payload (already includes the provider stamp). */
+  write: () => Promise<void>;
+}): Promise<{ written: boolean; verdict: StripeWriteVerdict | null }> {
+  const projection = await readBillingProjection(params.userId);
+  if (projection === null) {
+    logWebhookWarning(
+      `[${params.handler}] No profile for user ${params.userId} - skipping billing write`,
+    );
+    return { written: false, verdict: null };
+  }
+
+  const verdict = decideStripeProfileWrite(projection, params.fact);
+
+  if (verdict.decision.alert) {
+    await sendDoubleContractAlert(params.userId, verdict.decision.alert);
+  }
+
+  if (!verdict.allowed) {
+    logWebhookInfo(
+      `[${params.handler}] Stripe write BLOCKED by precedence guard (${verdict.blockedBy}) for user ${params.userId}: ` +
+        `current=${projection.provider}/${projection.plan}/${projection.status} incoming=${params.fact.plan}/${params.fact.status}`,
+    );
+    return { written: false, verdict };
+  }
+
+  await params.write();
+  return { written: true, verdict };
+}

--- a/apps/web/lib/stripe-webhook-handlers/refund-handlers.ts
+++ b/apps/web/lib/stripe-webhook-handlers/refund-handlers.ts
@@ -71,18 +71,23 @@ export async function handleChargeRefunded(
     }
 
     const currentPlan = userProfile[0].planSelected;
+    const currentProvider = userProfile[0].billingProvider;
 
     // Log refund details
     logWebhookDebug("Refund details", {
       userId,
       currentPlan,
+      currentProvider,
       isFullRefund,
       amountRefunded: formatAmount(amountRefunded, currency),
       amountCharged: formatAmount(amountCharged, currency),
     });
 
-    // For lifetime plans, full refund = revoke access
-    if (currentPlan === "lifetime" && isFullRefund) {
+    // For lifetime plans, full refund = revoke access. This is the ONE
+    // sanctioned lifetime overwrite: the refunded Stripe charge IS the
+    // lifetime payment. It only applies to a STRIPE-billed lifetime — a
+    // Stripe refund must never revoke an apple-billed entitlement.
+    if (currentPlan === "lifetime" && isFullRefund && currentProvider !== "apple") {
       logPaymentEvent(
         `Full refund detected - revoking lifetime access for user ${userId}`
       );
@@ -95,12 +100,17 @@ export async function handleChargeRefunded(
           subscriptionStatus: "canceled",
           currentPeriodEnd: null,
           cancelAtPeriodEnd: false,
+          billingProvider: null,
           billingVersion: sql`billing_version + 1`,
         })
         .where(eq(profile.id, userId));
 
       logWebhookSuccess(
         `Revoked lifetime access for user ${userId} due to full refund`
+      );
+    } else if (currentPlan === "lifetime" && isFullRefund) {
+      logWebhookWarning(
+        `Full Stripe refund for user ${userId} whose lifetime is billed by ${currentProvider} - NOT revoking (cross-provider mismatch, investigate manually)`
       );
     } else if (isFullRefund) {
       // Full refund for subscription - let subscription.deleted handle it

--- a/apps/web/lib/stripe-webhook-handlers/subscription-handlers.ts
+++ b/apps/web/lib/stripe-webhook-handlers/subscription-handlers.ts
@@ -12,6 +12,8 @@ import {
 import { verifyCustomerOwnership } from "@/lib/stripe-security";
 import { verifyPaymentAmount, formatAmount } from "@/utils/billing/pricing";
 import { logger } from "@/lib/logging";
+import type { BillingFact } from "@/utils/billing/apply-billing-event";
+import { guardedStripeProfileWrite } from "./profile-billing-write";
 import type { WebhookContext, WebhookResult } from "./types";
 
 /**
@@ -166,6 +168,7 @@ export async function handleSubscriptionChange(
         subscriptionStatus: subscription.status,
         currentPeriodEnd: subscription.items.data[0]?.current_period_end,
         cancelAtPeriodEnd: isCancelling,
+        billingProvider: "stripe" as const,
         billingVersion: sql`billing_version + 1`,
       };
 
@@ -180,12 +183,38 @@ export async function handleSubscriptionChange(
         },
       });
 
-      const result = await db
-        .update(profile)
-        .set(updateData)
-        .where(eq(profile.id, userId));
+      // Precedence guards (D-precedence): never overwrite lifetime, never
+      // clobber an apple-active contract. Stripe stays unordered (no cursor).
+      const fact: BillingFact = {
+        provider: "stripe",
+        plan,
+        status: subscription.status === "trialing" ? "trialing" : "active",
+        currentPeriodEnd:
+          subscription.items.data[0]?.current_period_end ?? null,
+        cancelAtPeriodEnd: isCancelling,
+        eventTimeMs: ctx.event.created * 1000,
+        eventId: ctx.eventId,
+      };
 
-      logger.debug("[Webhook] Database update result", { result });
+      const { written } = await guardedStripeProfileWrite({
+        userId,
+        handler: "handleSubscriptionChange",
+        fact,
+        write: async () => {
+          const result = await db
+            .update(profile)
+            .set(updateData)
+            .where(eq(profile.id, userId));
+          logger.debug("[Webhook] Database update result", { result });
+        },
+      });
+
+      if (!written) {
+        logWebhookInfo(
+          `Subscription change for user ${userId} not written (precedence guard)`,
+        );
+        return { success: true, message: "Blocked by precedence guard" };
+      }
 
       // Verify the update actually happened
       const verifyProfile = await db
@@ -271,24 +300,49 @@ export async function handleSubscriptionDeleted(
     );
   }
 
-  // Revert to free tier
+  // Revert to free tier — guarded: a dying stripe subscription must never
+  // strip a lifetime entitlement or an apple-billed contract.
   try {
-    await db
-      .update(profile)
-      .set({
-        planSelected: "free",
-        planSelectedAt: new Date(),
-        subscriptionStatus: "canceled",
-        currentPeriodEnd: null,
-        cancelAtPeriodEnd: false,
-        billingVersion: sql`billing_version + 1`,
-      })
-      .where(eq(profile.id, userId));
+    const fact: BillingFact = {
+      provider: "stripe",
+      plan: "free",
+      status: "canceled",
+      currentPeriodEnd: null,
+      cancelAtPeriodEnd: false,
+      eventTimeMs: ctx.event.created * 1000,
+      eventId: ctx.eventId,
+    };
 
-    logWebhookSuccess(`Reverted to free tier for user: ${userId}`);
-    logger.debug(
-      `[Webhook] Billing version incremented for user ${userId} - BillingSync should detect within seconds`,
-    );
+    const { written } = await guardedStripeProfileWrite({
+      userId,
+      handler: "handleSubscriptionDeleted",
+      fact,
+      write: async () => {
+        await db
+          .update(profile)
+          .set({
+            planSelected: "free",
+            planSelectedAt: new Date(),
+            subscriptionStatus: "canceled",
+            currentPeriodEnd: null,
+            cancelAtPeriodEnd: false,
+            billingProvider: null,
+            billingVersion: sql`billing_version + 1`,
+          })
+          .where(eq(profile.id, userId));
+      },
+    });
+
+    if (written) {
+      logWebhookSuccess(`Reverted to free tier for user: ${userId}`);
+      logger.debug(
+        `[Webhook] Billing version incremented for user ${userId} - BillingSync should detect within seconds`,
+      );
+    } else {
+      logWebhookInfo(
+        `Subscription deletion for user ${userId} did not revert plan (precedence guard)`,
+      );
+    }
   } catch (error) {
     logWebhookError("Error reverting user to free tier", error);
     throw error;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@handicappin/billing-core": "workspace:*",
     "@handicappin/handicap-core": "workspace:*",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-avatar": "^1.1.11",

--- a/apps/web/tests/integration/revenuecat-webhook.test.ts
+++ b/apps/web/tests/integration/revenuecat-webhook.test.ts
@@ -1,0 +1,778 @@
+/**
+ * RevenueCat Webhook Integration Tests (handoff DoD #5)
+ *
+ * Hits the REAL route handler against the REAL local Supabase stack:
+ * a dedicated auth user + profile row are created for the suite, RC-shaped
+ * payloads are POSTed through the handler, and assertions read the actual
+ * profile/webhook_events tables through the same drizzle client the
+ * handler writes with.
+ *
+ * Requires `supabase start` (DATABASE_URL in .env.local points at it) —
+ * same expectation as the rest of the integration suite.
+ */
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from "vitest";
+import { randomUUID } from "crypto";
+import { NextRequest } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { and, eq } from "drizzle-orm";
+
+const WEBHOOK_AUTH_TOKEN = "Bearer rc-test-shared-secret";
+process.env.REVENUECAT_WEBHOOK_AUTH_TOKEN = WEBHOOK_AUTH_TOKEN;
+
+// Import AFTER the env var is set — @/env snapshots process.env at import.
+const { POST } = await import("@/app/api/webhooks/revenuecat/route");
+const { db } = await import("@/db");
+const { profile, webhookEvents } = await import("@/db/schema");
+const { APPLE_SKUS } = await import("@handicappin/billing-core");
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const databaseUrl = process.env.DATABASE_URL;
+
+const isLocalStack =
+  !!databaseUrl?.includes("127.0.0.1") || !!databaseUrl?.includes("localhost");
+
+const describeIfLocal =
+  supabaseUrl && serviceRoleKey && isLocalStack ? describe : describe.skip;
+
+const TEST_EMAIL = "rc-webhook-test@handicappin.local";
+
+let userId: string;
+
+/** Monotonic event clock — each call is 1s later than the previous. */
+let clockMs = Date.now();
+function nextEventTime(): number {
+  clockMs += 1000;
+  return clockMs;
+}
+
+interface RcEventOverrides {
+  [key: string]: unknown;
+}
+
+function rcPayload(
+  type: string,
+  overrides: RcEventOverrides = {},
+): Record<string, unknown> {
+  return {
+    api_version: "1.0",
+    event: {
+      id: randomUUID(),
+      type,
+      event_timestamp_ms: nextEventTime(),
+      app_user_id: userId,
+      original_app_user_id: userId,
+      aliases: [userId],
+      store: "APP_STORE",
+      environment: "SANDBOX",
+      period_type: "NORMAL",
+      ...overrides,
+    },
+  };
+}
+
+function makeRequest(
+  body: unknown,
+  headers: Record<string, string> = { authorization: WEBHOOK_AUTH_TOKEN },
+): NextRequest {
+  return new NextRequest("http://localhost:3000/api/webhooks/revenuecat", {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+async function getProfileRow() {
+  const rows = await db
+    .select({
+      planSelected: profile.planSelected,
+      subscriptionStatus: profile.subscriptionStatus,
+      currentPeriodEnd: profile.currentPeriodEnd,
+      cancelAtPeriodEnd: profile.cancelAtPeriodEnd,
+      billingProvider: profile.billingProvider,
+      billingVersion: profile.billingVersion,
+    })
+    .from(profile)
+    .where(eq(profile.id, userId))
+    .limit(1);
+  expect(rows.length).toBe(1);
+  return rows[0];
+}
+
+async function setProfileBilling(state: {
+  plan: string | null;
+  status: string | null;
+  periodEnd?: number | null;
+  cancelAtPeriodEnd?: boolean;
+  provider?: string | null;
+}) {
+  await db
+    .update(profile)
+    .set({
+      planSelected: state.plan as never,
+      subscriptionStatus: state.status as never,
+      currentPeriodEnd: state.periodEnd ?? null,
+      cancelAtPeriodEnd: state.cancelAtPeriodEnd ?? false,
+      billingProvider: (state.provider ?? null) as never,
+    })
+    .where(eq(profile.id, userId));
+}
+
+async function clearWebhookEventsForUser() {
+  await db.delete(webhookEvents).where(eq(webhookEvents.userId, userId));
+}
+
+const FUTURE_MS = Date.parse("2027-06-12T00:00:00.000Z");
+const FUTURE_S = Math.floor(FUTURE_MS / 1000);
+const LATER_MS = FUTURE_MS + 30 * 86_400_000;
+const LATER_S = Math.floor(LATER_MS / 1000);
+
+describeIfLocal("RevenueCat webhook (real local Supabase)", () => {
+  beforeAll(async () => {
+    const admin = createClient(supabaseUrl!, serviceRoleKey!, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+
+    // Recreate the suite user from scratch.
+    const { data: usersPage } = await admin.auth.admin.listUsers();
+    const existing = usersPage?.users.find((u) => u.email === TEST_EMAIL);
+    if (existing) {
+      await db.delete(webhookEvents).where(eq(webhookEvents.userId, existing.id));
+      await db.delete(profile).where(eq(profile.id, existing.id));
+      await admin.auth.admin.deleteUser(existing.id);
+    }
+
+    const { data: created, error } = await admin.auth.admin.createUser({
+      email: TEST_EMAIL,
+      email_confirm: true,
+      password: randomUUID(),
+    });
+    if (error || !created.user) {
+      throw new Error(`Failed to create RC test user: ${error?.message}`);
+    }
+    userId = created.user.id;
+
+    await db.insert(profile).values({
+      id: userId,
+      email: TEST_EMAIL,
+      name: "RC Webhook Test",
+      verified: true,
+    });
+  }, 30_000);
+
+  afterAll(async () => {
+    if (!userId) return;
+    const admin = createClient(supabaseUrl!, serviceRoleKey!, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+    await db.delete(webhookEvents).where(eq(webhookEvents.userId, userId));
+    await db.delete(profile).where(eq(profile.id, userId));
+    await admin.auth.admin.deleteUser(userId);
+  }, 30_000);
+
+  beforeEach(async () => {
+    // Each test starts from a clean slate: plan-less profile, empty cursor.
+    await clearWebhookEventsForUser();
+    await setProfileBilling({ plan: null, status: null, provider: null });
+  });
+
+  // -------------------------------------------------------------------------
+  // Security / protocol
+  // -------------------------------------------------------------------------
+
+  test("bad Authorization header → 401, nothing recorded", async () => {
+    const res = await POST(
+      makeRequest(rcPayload("INITIAL_PURCHASE"), {
+        authorization: "Bearer wrong-secret",
+      }),
+    );
+    expect(res.status).toBe(401);
+    const row = await getProfileRow();
+    expect(row.planSelected).toBeNull();
+  });
+
+  test("missing Authorization header → 401", async () => {
+    const res = await POST(makeRequest(rcPayload("INITIAL_PURCHASE"), {}));
+    expect(res.status).toBe(401);
+  });
+
+  test("invalid JSON body → 400", async () => {
+    const req = new NextRequest("http://localhost:3000/api/webhooks/revenuecat", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: WEBHOOK_AUTH_TOKEN,
+      },
+      body: "not-json{",
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  test("schema-invalid payload (no event id) → 400", async () => {
+    const payload = rcPayload("INITIAL_PURCHASE");
+    delete (payload.event as Record<string, unknown>).id;
+    const res = await POST(makeRequest(payload));
+    expect(res.status).toBe(400);
+  });
+
+  // -------------------------------------------------------------------------
+  // Event mapping (D-status-mapping)
+  // -------------------------------------------------------------------------
+
+  test("INITIAL_PURCHASE (premium yearly) grants premium/active/apple", async () => {
+    const before = await getProfileRow();
+    const res = await POST(
+      makeRequest(
+        rcPayload("INITIAL_PURCHASE", {
+          product_id: APPLE_SKUS.premiumYearly,
+          expiration_at_ms: FUTURE_MS,
+          purchased_at_ms: Date.now(),
+        }),
+      ),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.applied).toBe(true);
+    expect(body.changed).toBe(true);
+
+    const row = await getProfileRow();
+    expect(row.planSelected).toBe("premium");
+    expect(row.subscriptionStatus).toBe("active");
+    expect(row.billingProvider).toBe("apple");
+    expect(row.currentPeriodEnd).toBe(FUTURE_S);
+    expect(row.cancelAtPeriodEnd).toBe(false);
+    expect(row.billingVersion).toBe(before.billingVersion + 1);
+  });
+
+  test("INITIAL_PURCHASE with TRIAL period maps to trialing", async () => {
+    await POST(
+      makeRequest(
+        rcPayload("INITIAL_PURCHASE", {
+          product_id: APPLE_SKUS.unlimitedYearly,
+          expiration_at_ms: FUTURE_MS,
+          period_type: "TRIAL",
+        }),
+      ),
+    );
+    const row = await getProfileRow();
+    expect(row.planSelected).toBe("unlimited");
+    expect(row.subscriptionStatus).toBe("trialing");
+  });
+
+  test("RENEWAL extends the period", async () => {
+    await POST(
+      makeRequest(
+        rcPayload("INITIAL_PURCHASE", {
+          product_id: APPLE_SKUS.unlimitedYearly,
+          expiration_at_ms: FUTURE_MS,
+        }),
+      ),
+    );
+    const res = await POST(
+      makeRequest(
+        rcPayload("RENEWAL", {
+          product_id: APPLE_SKUS.unlimitedYearly,
+          expiration_at_ms: LATER_MS,
+        }),
+      ),
+    );
+    expect(res.status).toBe(200);
+    const row = await getProfileRow();
+    expect(row.currentPeriodEnd).toBe(LATER_S);
+    expect(row.subscriptionStatus).toBe("active");
+  });
+
+  test("PRODUCT_CHANGE is acknowledged but writes nothing (RENEWAL carries the product)", async () => {
+    await POST(
+      makeRequest(
+        rcPayload("INITIAL_PURCHASE", {
+          product_id: APPLE_SKUS.unlimitedYearly,
+          expiration_at_ms: FUTURE_MS,
+        }),
+      ),
+    );
+    const before = await getProfileRow();
+
+    const res = await POST(
+      makeRequest(
+        rcPayload("PRODUCT_CHANGE", {
+          product_id: APPLE_SKUS.unlimitedYearly,
+          new_product_id: APPLE_SKUS.premiumYearly,
+          expiration_at_ms: FUTURE_MS,
+        }),
+      ),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.skipped).toBe("product-change-informational");
+
+    const after = await getProfileRow();
+    expect(after).toEqual(before);
+
+    // The deferred downgrade lands via RENEWAL with the new product.
+    await POST(
+      makeRequest(
+        rcPayload("RENEWAL", {
+          product_id: APPLE_SKUS.premiumYearly,
+          expiration_at_ms: LATER_MS,
+        }),
+      ),
+    );
+    const downgraded = await getProfileRow();
+    expect(downgraded.planSelected).toBe("premium");
+  });
+
+  test("CANCELLATION sets cancel_at_period_end, keeps entitlement until period end", async () => {
+    await POST(
+      makeRequest(
+        rcPayload("INITIAL_PURCHASE", {
+          product_id: APPLE_SKUS.premiumYearly,
+          expiration_at_ms: FUTURE_MS,
+        }),
+      ),
+    );
+    const res = await POST(
+      makeRequest(
+        rcPayload("CANCELLATION", {
+          product_id: APPLE_SKUS.premiumYearly,
+          cancel_reason: "UNSUBSCRIBE",
+          expiration_at_ms: FUTURE_MS,
+        }),
+      ),
+    );
+    expect(res.status).toBe(200);
+    const row = await getProfileRow();
+    expect(row.cancelAtPeriodEnd).toBe(true);
+    expect(row.planSelected).toBe("premium");
+    expect(row.subscriptionStatus).toBe("active");
+    expect(row.currentPeriodEnd).toBe(FUTURE_S);
+  });
+
+  test("UNCANCELLATION clears cancel_at_period_end", async () => {
+    await POST(
+      makeRequest(
+        rcPayload("INITIAL_PURCHASE", {
+          product_id: APPLE_SKUS.premiumYearly,
+          expiration_at_ms: FUTURE_MS,
+        }),
+      ),
+    );
+    await POST(
+      makeRequest(
+        rcPayload("CANCELLATION", {
+          product_id: APPLE_SKUS.premiumYearly,
+          cancel_reason: "UNSUBSCRIBE",
+        }),
+      ),
+    );
+    const res = await POST(
+      makeRequest(
+        rcPayload("UNCANCELLATION", {
+          product_id: APPLE_SKUS.premiumYearly,
+        }),
+      ),
+    );
+    expect(res.status).toBe(200);
+    const row = await getProfileRow();
+    expect(row.cancelAtPeriodEnd).toBe(false);
+    expect(row.subscriptionStatus).toBe("active");
+  });
+
+  test("BILLING_ISSUE moves status to past_due (denies access immediately)", async () => {
+    await POST(
+      makeRequest(
+        rcPayload("INITIAL_PURCHASE", {
+          product_id: APPLE_SKUS.unlimitedYearly,
+          expiration_at_ms: FUTURE_MS,
+        }),
+      ),
+    );
+    const res = await POST(
+      makeRequest(
+        rcPayload("BILLING_ISSUE", {
+          product_id: APPLE_SKUS.unlimitedYearly,
+          expiration_at_ms: FUTURE_MS,
+          grace_period_expiration_at_ms: LATER_MS,
+        }),
+      ),
+    );
+    expect(res.status).toBe(200);
+    const row = await getProfileRow();
+    expect(row.subscriptionStatus).toBe("past_due");
+    expect(row.planSelected).toBe("unlimited");
+    expect(row.billingProvider).toBe("apple");
+  });
+
+  test("EXPIRATION reverts to free/canceled and clears the provider", async () => {
+    await POST(
+      makeRequest(
+        rcPayload("INITIAL_PURCHASE", {
+          product_id: APPLE_SKUS.premiumYearly,
+          expiration_at_ms: FUTURE_MS,
+        }),
+      ),
+    );
+    const res = await POST(
+      makeRequest(
+        rcPayload("EXPIRATION", {
+          product_id: APPLE_SKUS.premiumYearly,
+          expiration_reason: "UNSUBSCRIBE",
+        }),
+      ),
+    );
+    expect(res.status).toBe(200);
+    const row = await getProfileRow();
+    expect(row.planSelected).toBe("free");
+    expect(row.subscriptionStatus).toBe("canceled");
+    expect(row.billingProvider).toBeNull();
+    expect(row.currentPeriodEnd).toBeNull();
+    expect(row.cancelAtPeriodEnd).toBe(false);
+  });
+
+  test("NON_RENEWING_PURCHASE of the lifetime SKU grants lifetime", async () => {
+    const res = await POST(
+      makeRequest(
+        rcPayload("NON_RENEWING_PURCHASE", {
+          product_id: APPLE_SKUS.lifetime,
+        }),
+      ),
+    );
+    expect(res.status).toBe(200);
+    const row = await getProfileRow();
+    expect(row.planSelected).toBe("lifetime");
+    expect(row.subscriptionStatus).toBe("active");
+    expect(row.billingProvider).toBe("apple");
+    expect(row.currentPeriodEnd).toBeNull();
+  });
+
+  test("unknown product id is acknowledged without write", async () => {
+    const res = await POST(
+      makeRequest(
+        rcPayload("INITIAL_PURCHASE", {
+          product_id: "com.handicappin.bogus.monthly",
+          expiration_at_ms: FUTURE_MS,
+        }),
+      ),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.skipped).toBe("unknown-product");
+    const row = await getProfileRow();
+    expect(row.planSelected).toBeNull();
+  });
+
+  test("non-APP_STORE store is acknowledged without write (D-rc-scope)", async () => {
+    const res = await POST(
+      makeRequest(
+        rcPayload("INITIAL_PURCHASE", {
+          product_id: APPLE_SKUS.premiumYearly,
+          store: "PLAY_STORE",
+          expiration_at_ms: FUTURE_MS,
+        }),
+      ),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.skipped).toBe("unsupported-store");
+  });
+
+  test("TRANSFER is alert-only: no entitlement write, alert recorded", async () => {
+    await setProfileBilling({
+      plan: "premium",
+      status: "active",
+      provider: "apple",
+      periodEnd: FUTURE_S,
+    });
+    const payload = rcPayload("TRANSFER", {
+      transferred_from: ["some-old-user"],
+      transferred_to: [userId],
+    });
+    delete (payload.event as Record<string, unknown>).app_user_id;
+    const eventId = (payload.event as Record<string, unknown>).id as string;
+
+    const res = await POST(makeRequest(payload));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.transfer).toBe(true);
+    expect(body.alerted).toBe(true);
+
+    const row = await getProfileRow();
+    expect(row.planSelected).toBe("premium"); // untouched
+
+    const recorded = await db
+      .select()
+      .from(webhookEvents)
+      .where(eq(webhookEvents.eventId, eventId))
+      .limit(1);
+    expect(recorded.length).toBe(1);
+    expect(recorded[0].status).toBe("success");
+    expect(recorded[0].errorMessage).toContain("transfer:");
+    expect(recorded[0].eventTimeMs).toBeNull(); // cursor NOT advanced
+  });
+
+  // -------------------------------------------------------------------------
+  // Idempotency + ordering
+  // -------------------------------------------------------------------------
+
+  test("duplicate event id → idempotent 200, no second apply", async () => {
+    const payload = rcPayload("INITIAL_PURCHASE", {
+      product_id: APPLE_SKUS.premiumYearly,
+      expiration_at_ms: FUTURE_MS,
+    });
+    const first = await POST(makeRequest(payload));
+    expect(first.status).toBe(200);
+    const afterFirst = await getProfileRow();
+
+    const second = await POST(makeRequest(payload));
+    expect(second.status).toBe(200);
+    const body = await second.json();
+    expect(body.duplicate).toBe(true);
+
+    const afterSecond = await getProfileRow();
+    expect(afterSecond).toEqual(afterFirst); // billing_version untouched
+  });
+
+  test("stale event (older than the applied cursor) is ignored", async () => {
+    // Apply a purchase at t, then replay an older-but-different event.
+    const purchase = rcPayload("INITIAL_PURCHASE", {
+      product_id: APPLE_SKUS.unlimitedYearly,
+      expiration_at_ms: FUTURE_MS,
+    });
+    const purchaseTime = (purchase.event as Record<string, unknown>)
+      .event_timestamp_ms as number;
+    await POST(makeRequest(purchase));
+    const applied = await getProfileRow();
+
+    const stale = rcPayload("CANCELLATION", {
+      product_id: APPLE_SKUS.unlimitedYearly,
+      cancel_reason: "UNSUBSCRIBE",
+    });
+    (stale.event as Record<string, unknown>).event_timestamp_ms =
+      purchaseTime - 60_000;
+
+    const res = await POST(makeRequest(stale));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.stale).toBe(true);
+
+    const after = await getProfileRow();
+    expect(after).toEqual(applied); // cancellation did NOT apply
+  });
+
+  // -------------------------------------------------------------------------
+  // Cross-provider precedence through the real route
+  // -------------------------------------------------------------------------
+
+  test("double-contract: apple purchase over ACTIVE stripe sub keeps max entitlement + records alert", async () => {
+    await setProfileBilling({
+      plan: "premium",
+      status: "active",
+      provider: "stripe",
+      periodEnd: FUTURE_S,
+    });
+    const payload = rcPayload("INITIAL_PURCHASE", {
+      product_id: APPLE_SKUS.unlimitedYearly,
+      expiration_at_ms: LATER_MS,
+    });
+    const eventId = (payload.event as Record<string, unknown>).id as string;
+
+    const res = await POST(makeRequest(payload));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.doubleContract).toBe(true);
+
+    // Max entitlement: apple unlimited beats stripe premium.
+    const row = await getProfileRow();
+    expect(row.planSelected).toBe("unlimited");
+    expect(row.billingProvider).toBe("apple");
+
+    const recorded = await db
+      .select()
+      .from(webhookEvents)
+      .where(eq(webhookEvents.eventId, eventId))
+      .limit(1);
+    expect(recorded[0].errorMessage).toContain("double_contract: kept apple");
+  });
+
+  test("double-contract: LOWER apple tier does not displace stripe unlimited — state preserved + alert recorded", async () => {
+    await setProfileBilling({
+      plan: "unlimited",
+      status: "active",
+      provider: "stripe",
+      periodEnd: FUTURE_S,
+    });
+    const payload = rcPayload("INITIAL_PURCHASE", {
+      product_id: APPLE_SKUS.premiumYearly,
+      expiration_at_ms: LATER_MS,
+    });
+    const eventId = (payload.event as Record<string, unknown>).id as string;
+
+    const res = await POST(makeRequest(payload));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.doubleContract).toBe(true);
+    expect(body.applied).toBe(false);
+
+    const row = await getProfileRow();
+    expect(row.planSelected).toBe("unlimited");
+    expect(row.billingProvider).toBe("stripe"); // never auto-cancelled/changed
+
+    const recorded = await db
+      .select()
+      .from(webhookEvents)
+      .where(eq(webhookEvents.eventId, eventId))
+      .limit(1);
+    expect(recorded[0].errorMessage).toContain("double_contract: kept stripe");
+  });
+
+  test("lifetime is never overwritten: apple EXPIRATION cannot kill a stripe lifetime", async () => {
+    await setProfileBilling({
+      plan: "lifetime",
+      status: "active",
+      provider: "stripe",
+    });
+    const res = await POST(
+      makeRequest(
+        rcPayload("EXPIRATION", {
+          product_id: APPLE_SKUS.premiumYearly,
+          expiration_reason: "UNSUBSCRIBE",
+        }),
+      ),
+    );
+    expect(res.status).toBe(200);
+    const row = await getProfileRow();
+    expect(row.planSelected).toBe("lifetime");
+    expect(row.billingProvider).toBe("stripe");
+  });
+
+  test("apple events for a stripe-active user's foreign dead contract are ignored", async () => {
+    await setProfileBilling({
+      plan: "premium",
+      status: "active",
+      provider: "stripe",
+      periodEnd: FUTURE_S,
+    });
+    const res = await POST(
+      makeRequest(
+        rcPayload("EXPIRATION", {
+          product_id: APPLE_SKUS.premiumYearly,
+          expiration_reason: "UNSUBSCRIBE",
+        }),
+      ),
+    );
+    expect(res.status).toBe(200);
+    const row = await getProfileRow();
+    expect(row.planSelected).toBe("premium");
+    expect(row.billingProvider).toBe("stripe");
+  });
+
+  test("full lifecycle: purchase → billing issue → recovery renewal → cancel → expire", async () => {
+    await POST(
+      makeRequest(
+        rcPayload("INITIAL_PURCHASE", {
+          product_id: APPLE_SKUS.unlimitedYearly,
+          expiration_at_ms: FUTURE_MS,
+        }),
+      ),
+    );
+    await POST(
+      makeRequest(
+        rcPayload("BILLING_ISSUE", {
+          product_id: APPLE_SKUS.unlimitedYearly,
+          expiration_at_ms: FUTURE_MS,
+        }),
+      ),
+    );
+    expect((await getProfileRow()).subscriptionStatus).toBe("past_due");
+
+    await POST(
+      makeRequest(
+        rcPayload("RENEWAL", {
+          product_id: APPLE_SKUS.unlimitedYearly,
+          expiration_at_ms: LATER_MS,
+        }),
+      ),
+    );
+    const recovered = await getProfileRow();
+    expect(recovered.subscriptionStatus).toBe("active");
+    expect(recovered.currentPeriodEnd).toBe(LATER_S);
+
+    await POST(
+      makeRequest(
+        rcPayload("CANCELLATION", {
+          product_id: APPLE_SKUS.unlimitedYearly,
+          cancel_reason: "UNSUBSCRIBE",
+        }),
+      ),
+    );
+    expect((await getProfileRow()).cancelAtPeriodEnd).toBe(true);
+
+    await POST(
+      makeRequest(
+        rcPayload("EXPIRATION", {
+          product_id: APPLE_SKUS.unlimitedYearly,
+          expiration_reason: "UNSUBSCRIBE",
+        }),
+      ),
+    );
+    const expired = await getProfileRow();
+    expect(expired.planSelected).toBe("free");
+    expect(expired.billingProvider).toBeNull();
+  });
+
+  test("TEST event from the RC dashboard is acknowledged without write", async () => {
+    const res = await POST(makeRequest(rcPayload("TEST")));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.skipped).toBe("test-event");
+  });
+
+  test("unhandled event types (e.g. SUBSCRIPTION_EXTENDED) are acknowledged and recorded without cursor advance", async () => {
+    const payload = rcPayload("SUBSCRIPTION_EXTENDED", {
+      product_id: APPLE_SKUS.premiumYearly,
+      expiration_at_ms: LATER_MS,
+    });
+    const eventId = (payload.event as Record<string, unknown>).id as string;
+    const res = await POST(makeRequest(payload));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.skipped).toBe("unhandled-type");
+
+    const recorded = await db
+      .select()
+      .from(webhookEvents)
+      .where(eq(webhookEvents.eventId, eventId))
+      .limit(1);
+    expect(recorded[0].eventTimeMs).toBeNull();
+  });
+
+  test("events recorded with provider=apple and event time advance the cursor", async () => {
+    const payload = rcPayload("INITIAL_PURCHASE", {
+      product_id: APPLE_SKUS.premiumYearly,
+      expiration_at_ms: FUTURE_MS,
+    });
+    const eventId = (payload.event as Record<string, unknown>).id as string;
+    const eventTime = (payload.event as Record<string, unknown>)
+      .event_timestamp_ms as number;
+    await POST(makeRequest(payload));
+
+    const recorded = await db
+      .select()
+      .from(webhookEvents)
+      .where(
+        and(eq(webhookEvents.eventId, eventId), eq(webhookEvents.status, "success")),
+      )
+      .limit(1);
+    expect(recorded[0].provider).toBe("apple");
+    expect(recorded[0].eventTimeMs).toBe(eventTime);
+    expect(recorded[0].eventType).toBe("revenuecat.INITIAL_PURCHASE");
+  });
+});

--- a/apps/web/tests/integration/revenuecat-webhook.test.ts
+++ b/apps/web/tests/integration/revenuecat-webhook.test.ts
@@ -39,8 +39,18 @@ const databaseUrl = process.env.DATABASE_URL;
 const isLocalStack =
   !!databaseUrl?.includes("127.0.0.1") || !!databaseUrl?.includes("localhost");
 
+// CI points DATABASE_URL at a localhost placeholder but supplies DUMMY Supabase
+// credentials (no real stack is provisioned). Dummy creds must count as "no
+// local stack" so this suite skips in CI and runs only against a real
+// `supabase start` — matching the dummy-key guard the Stripe suites use.
+const hasRealSupabase =
+  !!supabaseUrl &&
+  !supabaseUrl.includes("dummy") &&
+  !!serviceRoleKey &&
+  !serviceRoleKey.includes("dummy");
+
 const describeIfLocal =
-  supabaseUrl && serviceRoleKey && isLocalStack ? describe : describe.skip;
+  hasRealSupabase && isLocalStack ? describe : describe.skip;
 
 const TEST_EMAIL = "rc-webhook-test@handicappin.local";
 

--- a/apps/web/tests/integration/stripe-billing-guards.test.ts
+++ b/apps/web/tests/integration/stripe-billing-guards.test.ts
@@ -31,8 +31,18 @@ const databaseUrl = process.env.DATABASE_URL;
 const isLocalStack =
   !!databaseUrl?.includes("127.0.0.1") || !!databaseUrl?.includes("localhost");
 
+// CI points DATABASE_URL at a localhost placeholder but supplies DUMMY Supabase
+// credentials (no real stack is provisioned). Dummy creds must count as "no
+// local stack" so this suite skips in CI and runs only against a real
+// `supabase start` — matching the dummy-key guard the Stripe suites use.
+const hasRealSupabase =
+  !!supabaseUrl &&
+  !supabaseUrl.includes("dummy") &&
+  !!serviceRoleKey &&
+  !serviceRoleKey.includes("dummy");
+
 const describeIfLocal =
-  supabaseUrl && serviceRoleKey && isLocalStack ? describe : describe.skip;
+  hasRealSupabase && isLocalStack ? describe : describe.skip;
 
 const TEST_EMAIL = "stripe-guards-test@handicappin.local";
 const FUTURE_S = Math.floor(Date.parse("2027-06-12T00:00:00Z") / 1000);

--- a/apps/web/tests/integration/stripe-billing-guards.test.ts
+++ b/apps/web/tests/integration/stripe-billing-guards.test.ts
@@ -1,0 +1,352 @@
+/**
+ * Stripe precedence-guard integration tests (handoff DoD #4).
+ *
+ * Exercises guardedStripeProfileWrite — the seam every Stripe webhook
+ * handler now routes its final profile write through — against the REAL
+ * local Supabase stack: seeded projection states, stripe-shaped facts,
+ * assertions on the actual profile row.
+ */
+import {
+  describe,
+  test,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from "vitest";
+import { randomUUID } from "crypto";
+import { createClient } from "@supabase/supabase-js";
+import { eq } from "drizzle-orm";
+import { sql } from "drizzle-orm";
+
+const { db } = await import("@/db");
+const { profile, webhookEvents } = await import("@/db/schema");
+const { guardedStripeProfileWrite, decideStripeProfileWrite } = await import(
+  "@/lib/stripe-webhook-handlers/profile-billing-write"
+);
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const databaseUrl = process.env.DATABASE_URL;
+const isLocalStack =
+  !!databaseUrl?.includes("127.0.0.1") || !!databaseUrl?.includes("localhost");
+
+const describeIfLocal =
+  supabaseUrl && serviceRoleKey && isLocalStack ? describe : describe.skip;
+
+const TEST_EMAIL = "stripe-guards-test@handicappin.local";
+const FUTURE_S = Math.floor(Date.parse("2027-06-12T00:00:00Z") / 1000);
+
+let userId: string;
+let factCounter = 0;
+
+function stripeFact(overrides: Record<string, unknown> = {}) {
+  factCounter += 1;
+  return {
+    provider: "stripe" as const,
+    plan: "premium" as const,
+    status: "active" as const,
+    currentPeriodEnd: FUTURE_S,
+    cancelAtPeriodEnd: false,
+    eventTimeMs: Date.now(),
+    eventId: `evt_guard_${factCounter}`,
+    ...overrides,
+  };
+}
+
+async function seedProjection(state: {
+  plan: string | null;
+  status: string | null;
+  provider: string | null;
+  periodEnd?: number | null;
+  cancelAtPeriodEnd?: boolean;
+}) {
+  await db
+    .update(profile)
+    .set({
+      planSelected: state.plan as never,
+      subscriptionStatus: state.status as never,
+      billingProvider: state.provider as never,
+      currentPeriodEnd: state.periodEnd ?? null,
+      cancelAtPeriodEnd: state.cancelAtPeriodEnd ?? false,
+    })
+    .where(eq(profile.id, userId));
+}
+
+async function getRow() {
+  const rows = await db
+    .select({
+      planSelected: profile.planSelected,
+      subscriptionStatus: profile.subscriptionStatus,
+      currentPeriodEnd: profile.currentPeriodEnd,
+      cancelAtPeriodEnd: profile.cancelAtPeriodEnd,
+      billingProvider: profile.billingProvider,
+    })
+    .from(profile)
+    .where(eq(profile.id, userId))
+    .limit(1);
+  return rows[0];
+}
+
+/** The write each test hands the guard — a full stripe-shaped update. */
+function profileWrite(fact: ReturnType<typeof stripeFact>) {
+  return async () => {
+    await db
+      .update(profile)
+      .set({
+        planSelected: fact.plan,
+        subscriptionStatus: fact.status,
+        currentPeriodEnd: fact.currentPeriodEnd,
+        cancelAtPeriodEnd: fact.cancelAtPeriodEnd,
+        billingProvider: "stripe",
+        billingVersion: sql`billing_version + 1`,
+      })
+      .where(eq(profile.id, userId));
+  };
+}
+
+describeIfLocal("Stripe precedence guards (real local Supabase)", () => {
+  beforeAll(async () => {
+    const admin = createClient(supabaseUrl!, serviceRoleKey!, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+    const { data: usersPage } = await admin.auth.admin.listUsers();
+    const existing = usersPage?.users.find((u) => u.email === TEST_EMAIL);
+    if (existing) {
+      await db.delete(webhookEvents).where(eq(webhookEvents.userId, existing.id));
+      await db.delete(profile).where(eq(profile.id, existing.id));
+      await admin.auth.admin.deleteUser(existing.id);
+    }
+    const { data: created, error } = await admin.auth.admin.createUser({
+      email: TEST_EMAIL,
+      email_confirm: true,
+      password: randomUUID(),
+    });
+    if (error || !created.user) {
+      throw new Error(`Failed to create guard test user: ${error?.message}`);
+    }
+    userId = created.user.id;
+    await db.insert(profile).values({
+      id: userId,
+      email: TEST_EMAIL,
+      name: "Stripe Guards Test",
+      verified: true,
+    });
+  }, 30_000);
+
+  afterAll(async () => {
+    if (!userId) return;
+    const admin = createClient(supabaseUrl!, serviceRoleKey!, {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+    await db.delete(webhookEvents).where(eq(webhookEvents.userId, userId));
+    await db.delete(profile).where(eq(profile.id, userId));
+    await admin.auth.admin.deleteUser(userId);
+  }, 30_000);
+
+  beforeEach(async () => {
+    await seedProjection({ plan: null, status: null, provider: null });
+  });
+
+  test("stripe write onto a plan-less profile applies and stamps the provider", async () => {
+    const fact = stripeFact();
+    const { written } = await guardedStripeProfileWrite({
+      userId,
+      handler: "test",
+      fact,
+      write: profileWrite(fact),
+    });
+    expect(written).toBe(true);
+    const row = await getRow();
+    expect(row.planSelected).toBe("premium");
+    expect(row.billingProvider).toBe("stripe");
+  });
+
+  test("stripe write onto its own contract applies (same-provider lifecycle)", async () => {
+    await seedProjection({
+      plan: "premium",
+      status: "active",
+      provider: "stripe",
+      periodEnd: FUTURE_S,
+    });
+    const fact = stripeFact({ plan: "unlimited" });
+    const { written } = await guardedStripeProfileWrite({
+      userId,
+      handler: "test",
+      fact,
+      write: profileWrite(fact),
+    });
+    expect(written).toBe(true);
+    expect((await getRow()).planSelected).toBe("unlimited");
+  });
+
+  test("NEVER overwrites lifetime: stripe subscription event vs stripe lifetime", async () => {
+    await seedProjection({
+      plan: "lifetime",
+      status: "active",
+      provider: "stripe",
+    });
+    const fact = stripeFact({ plan: "premium" });
+    const { written, verdict } = await guardedStripeProfileWrite({
+      userId,
+      handler: "test",
+      fact,
+      write: profileWrite(fact),
+    });
+    expect(written).toBe(false);
+    expect(verdict && !verdict.allowed && verdict.blockedBy).toBe(
+      "lifetime-locked",
+    );
+    const row = await getRow();
+    expect(row.planSelected).toBe("lifetime");
+  });
+
+  test("NEVER overwrites an apple lifetime either", async () => {
+    await seedProjection({
+      plan: "lifetime",
+      status: "active",
+      provider: "apple",
+    });
+    const fact = stripeFact({ plan: "unlimited" });
+    const { written } = await guardedStripeProfileWrite({
+      userId,
+      handler: "test",
+      fact,
+      write: profileWrite(fact),
+    });
+    expect(written).toBe(false);
+    const row = await getRow();
+    expect(row.planSelected).toBe("lifetime");
+    expect(row.billingProvider).toBe("apple");
+  });
+
+  test("never clobbers an apple-active contract with a lower stripe tier (alerted)", async () => {
+    await seedProjection({
+      plan: "unlimited",
+      status: "active",
+      provider: "apple",
+      periodEnd: FUTURE_S,
+    });
+    const fact = stripeFact({ plan: "premium" });
+    const { written, verdict } = await guardedStripeProfileWrite({
+      userId,
+      handler: "test",
+      fact,
+      write: profileWrite(fact),
+    });
+    expect(written).toBe(false);
+    expect(verdict && !verdict.allowed && verdict.blockedBy).toBe(
+      "double-contract-current-wins",
+    );
+    expect(verdict?.decision.alert?.keptProvider).toBe("apple");
+    const row = await getRow();
+    expect(row.billingProvider).toBe("apple");
+    expect(row.planSelected).toBe("unlimited");
+  });
+
+  test("a HIGHER stripe tier wins the double contract (and alerts)", async () => {
+    await seedProjection({
+      plan: "premium",
+      status: "active",
+      provider: "apple",
+      periodEnd: FUTURE_S,
+    });
+    const fact = stripeFact({ plan: "unlimited" });
+    const { written, verdict } = await guardedStripeProfileWrite({
+      userId,
+      handler: "test",
+      fact,
+      write: profileWrite(fact),
+    });
+    expect(written).toBe(true);
+    expect(verdict?.decision.alert?.keptProvider).toBe("stripe");
+    const row = await getRow();
+    expect(row.billingProvider).toBe("stripe");
+    expect(row.planSelected).toBe("unlimited");
+  });
+
+  test("stripe subscription-deleted (free fact) cannot kill an apple-active contract", async () => {
+    await seedProjection({
+      plan: "premium",
+      status: "active",
+      provider: "apple",
+      periodEnd: FUTURE_S,
+    });
+    const fact = stripeFact({
+      plan: "free",
+      status: "canceled",
+      currentPeriodEnd: null,
+    });
+    const { written, verdict } = await guardedStripeProfileWrite({
+      userId,
+      handler: "test",
+      fact,
+      write: profileWrite(fact),
+    });
+    expect(written).toBe(false);
+    expect(verdict && !verdict.allowed && verdict.blockedBy).toBe(
+      "inactive-foreign-contract",
+    );
+    const row = await getRow();
+    expect(row.planSelected).toBe("premium");
+    expect(row.billingProvider).toBe("apple");
+  });
+
+  test("stripe past_due fact cannot mark an apple-active contract past due", async () => {
+    await seedProjection({
+      plan: "unlimited",
+      status: "active",
+      provider: "apple",
+      periodEnd: FUTURE_S,
+    });
+    // Mirrors handleInvoicePaymentFailed's fact for a non-stripe projection.
+    const fact = stripeFact({
+      plan: null,
+      status: "past_due",
+      currentPeriodEnd: null,
+    });
+    const { written } = await guardedStripeProfileWrite({
+      userId,
+      handler: "test",
+      fact,
+      write: profileWrite(fact),
+    });
+    expect(written).toBe(false);
+    expect((await getRow()).subscriptionStatus).toBe("active");
+  });
+
+  test("stripe-active fact displaces a DEAD apple contract", async () => {
+    await seedProjection({
+      plan: "unlimited",
+      status: "past_due",
+      provider: "apple",
+      periodEnd: FUTURE_S,
+    });
+    const fact = stripeFact({ plan: "premium" });
+    const { written } = await guardedStripeProfileWrite({
+      userId,
+      handler: "test",
+      fact,
+      write: profileWrite(fact),
+    });
+    expect(written).toBe(true);
+    const row = await getRow();
+    expect(row.billingProvider).toBe("stripe");
+    expect(row.planSelected).toBe("premium");
+  });
+
+  test("decideStripeProfileWrite is pure and mirrors the chokepoint verdicts", () => {
+    const lifetimeProjection = {
+      provider: "apple" as const,
+      plan: "lifetime" as const,
+      status: "active" as const,
+      currentPeriodEnd: null,
+      cancelAtPeriodEnd: false,
+    };
+    const verdict = decideStripeProfileWrite(lifetimeProjection, stripeFact());
+    expect(verdict.allowed).toBe(false);
+    if (!verdict.allowed) {
+      expect(verdict.blockedBy).toBe("lifetime-locked");
+    }
+  });
+});

--- a/apps/web/tests/unit/lib/reconcile-billing-core.test.ts
+++ b/apps/web/tests/unit/lib/reconcile-billing-core.test.ts
@@ -1,0 +1,384 @@
+/**
+ * Unit tests for the reconcile script's pure diff logic
+ * (scripts/lib/reconcile-billing-core.mjs — handoff DoD #6).
+ */
+import { describe, test, expect } from "vitest";
+// eslint-disable-next-line import/no-relative-packages
+import {
+  normalizeStripeSubscriptions,
+  normalizeRevenueCatSubscriber,
+  diffBillingState,
+  decideApply,
+} from "../../../../../scripts/lib/reconcile-billing-core.mjs";
+
+const PRICE_TO_PLAN = {
+  price_premium: "premium",
+  price_unlimited: "unlimited",
+};
+
+const NOW = Date.parse("2026-06-12T00:00:00Z");
+const FUTURE_ISO = "2027-06-12T00:00:00Z";
+const FUTURE_S = Math.floor(Date.parse(FUTURE_ISO) / 1000);
+const PAST_ISO = "2025-06-12T00:00:00Z";
+
+function stripeSub(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "sub_1",
+    status: "active",
+    created: 1_700_000_000,
+    cancel_at_period_end: false,
+    cancel_at: null,
+    items: {
+      data: [
+        {
+          price: { id: "price_premium" },
+          current_period_end: FUTURE_S,
+        },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+describe("normalizeStripeSubscriptions", () => {
+  test("empty list → null (no record)", () => {
+    expect(normalizeStripeSubscriptions([], PRICE_TO_PLAN)).toBeNull();
+    expect(normalizeStripeSubscriptions(undefined, PRICE_TO_PLAN)).toBeNull();
+  });
+
+  test("active subscription maps plan/status/period/cap", () => {
+    const state = normalizeStripeSubscriptions([stripeSub()], PRICE_TO_PLAN);
+    expect(state).toEqual({
+      plan: "premium",
+      status: "active",
+      currentPeriodEnd: FUTURE_S,
+      cancelAtPeriodEnd: false,
+    });
+  });
+
+  test("cancel_at_period_end flows through", () => {
+    const state = normalizeStripeSubscriptions(
+      [stripeSub({ cancel_at_period_end: true })],
+      PRICE_TO_PLAN,
+    );
+    expect(state?.cancelAtPeriodEnd).toBe(true);
+  });
+
+  test("canceled subscription projects as the free tier", () => {
+    const state = normalizeStripeSubscriptions(
+      [stripeSub({ status: "canceled" })],
+      PRICE_TO_PLAN,
+    );
+    expect(state).toEqual({
+      plan: "free",
+      status: "canceled",
+      currentPeriodEnd: null,
+      cancelAtPeriodEnd: false,
+    });
+  });
+
+  test("prefers the live subscription over an old canceled one", () => {
+    const state = normalizeStripeSubscriptions(
+      [
+        stripeSub({ id: "sub_old", status: "canceled", created: 1 }),
+        stripeSub({
+          id: "sub_live",
+          created: 2,
+          items: {
+            data: [
+              { price: { id: "price_unlimited" }, current_period_end: FUTURE_S },
+            ],
+          },
+        }),
+      ],
+      PRICE_TO_PLAN,
+    );
+    expect(state?.plan).toBe("unlimited");
+    expect(state?.status).toBe("active");
+  });
+
+  test("past_due ranks above canceled but below active", () => {
+    const state = normalizeStripeSubscriptions(
+      [
+        stripeSub({ id: "a", status: "canceled", created: 3 }),
+        stripeSub({ id: "b", status: "past_due", created: 1 }),
+      ],
+      PRICE_TO_PLAN,
+    );
+    expect(state?.status).toBe("past_due");
+  });
+
+  test("unknown price maps plan to null (caught as a diff)", () => {
+    const state = normalizeStripeSubscriptions(
+      [
+        stripeSub({
+          items: {
+            data: [{ price: { id: "price_mystery" }, current_period_end: FUTURE_S }],
+          },
+        }),
+      ],
+      PRICE_TO_PLAN,
+    );
+    expect(state?.plan).toBeNull();
+  });
+});
+
+describe("normalizeRevenueCatSubscriber", () => {
+  test("null/empty subscriber → null", () => {
+    expect(normalizeRevenueCatSubscriber(null, NOW)).toBeNull();
+    expect(normalizeRevenueCatSubscriber({}, NOW)).toBeNull();
+  });
+
+  test("live app_store subscription maps to active with period end", () => {
+    const state = normalizeRevenueCatSubscriber(
+      {
+        subscriptions: {
+          "com.handicappin.premium.yearly": {
+            expires_date: FUTURE_ISO,
+            period_type: "normal",
+            store: "app_store",
+            unsubscribe_detected_at: null,
+            billing_issues_detected_at: null,
+          },
+        },
+      },
+      NOW,
+    );
+    expect(state).toEqual({
+      plan: "premium",
+      status: "active",
+      currentPeriodEnd: Math.floor(Date.parse(FUTURE_ISO) / 1000),
+      cancelAtPeriodEnd: false,
+    });
+  });
+
+  test("trial period maps to trialing", () => {
+    const state = normalizeRevenueCatSubscriber(
+      {
+        subscriptions: {
+          "com.handicappin.unlimited.yearly": {
+            expires_date: FUTURE_ISO,
+            period_type: "trial",
+            store: "app_store",
+          },
+        },
+      },
+      NOW,
+    );
+    expect(state?.status).toBe("trialing");
+    expect(state?.plan).toBe("unlimited");
+  });
+
+  test("billing issue maps to past_due", () => {
+    const state = normalizeRevenueCatSubscriber(
+      {
+        subscriptions: {
+          "com.handicappin.premium.yearly": {
+            expires_date: FUTURE_ISO,
+            period_type: "normal",
+            store: "app_store",
+            billing_issues_detected_at: "2026-06-01T00:00:00Z",
+          },
+        },
+      },
+      NOW,
+    );
+    expect(state?.status).toBe("past_due");
+  });
+
+  test("unsubscribe detected maps to cancelAtPeriodEnd", () => {
+    const state = normalizeRevenueCatSubscriber(
+      {
+        subscriptions: {
+          "com.handicappin.premium.yearly": {
+            expires_date: FUTURE_ISO,
+            period_type: "normal",
+            store: "app_store",
+            unsubscribe_detected_at: "2026-06-01T00:00:00Z",
+          },
+        },
+      },
+      NOW,
+    );
+    expect(state?.cancelAtPeriodEnd).toBe(true);
+    expect(state?.status).toBe("active");
+  });
+
+  test("expired subscription projects as free tier", () => {
+    const state = normalizeRevenueCatSubscriber(
+      {
+        subscriptions: {
+          "com.handicappin.premium.yearly": {
+            expires_date: PAST_ISO,
+            period_type: "normal",
+            store: "app_store",
+          },
+        },
+      },
+      NOW,
+    );
+    expect(state).toEqual({
+      plan: "free",
+      status: "canceled",
+      currentPeriodEnd: null,
+      cancelAtPeriodEnd: false,
+    });
+  });
+
+  test("refunded subscription projects as free tier even if unexpired", () => {
+    const state = normalizeRevenueCatSubscriber(
+      {
+        subscriptions: {
+          "com.handicappin.premium.yearly": {
+            expires_date: FUTURE_ISO,
+            period_type: "normal",
+            store: "app_store",
+            refunded_at: "2026-06-01T00:00:00Z",
+          },
+        },
+      },
+      NOW,
+    );
+    expect(state?.plan).toBe("free");
+  });
+
+  test("lifetime non-subscription purchase wins over everything", () => {
+    const state = normalizeRevenueCatSubscriber(
+      {
+        subscriptions: {
+          "com.handicappin.premium.yearly": {
+            expires_date: PAST_ISO,
+            period_type: "normal",
+            store: "app_store",
+          },
+        },
+        non_subscriptions: {
+          "com.handicappin.lifetime": [
+            { id: "txn1", purchase_date: PAST_ISO, store: "app_store" },
+          ],
+        },
+      },
+      NOW,
+    );
+    expect(state).toEqual({
+      plan: "lifetime",
+      status: "active",
+      currentPeriodEnd: null,
+      cancelAtPeriodEnd: false,
+    });
+  });
+
+  test("non-app_store subscriptions are ignored (D-rc-scope)", () => {
+    const state = normalizeRevenueCatSubscriber(
+      {
+        subscriptions: {
+          "com.handicappin.premium.yearly": {
+            expires_date: FUTURE_ISO,
+            period_type: "normal",
+            store: "stripe",
+          },
+        },
+      },
+      NOW,
+    );
+    expect(state).toBeNull();
+  });
+});
+
+describe("diffBillingState", () => {
+  const projection = {
+    plan: "premium",
+    status: "active",
+    currentPeriodEnd: FUTURE_S,
+    cancelAtPeriodEnd: false,
+    provider: "stripe",
+  };
+
+  test("identical states produce no diffs", () => {
+    expect(
+      diffBillingState(projection, {
+        plan: "premium",
+        status: "active",
+        currentPeriodEnd: FUTURE_S,
+        cancelAtPeriodEnd: false,
+      }),
+    ).toEqual([]);
+  });
+
+  test("field mismatches are reported individually", () => {
+    const diffs = diffBillingState(projection, {
+      plan: "unlimited",
+      status: "active",
+      currentPeriodEnd: FUTURE_S,
+      cancelAtPeriodEnd: true,
+    });
+    expect(diffs.map((d: { field: string }) => d.field).sort()).toEqual([
+      "cancelAtPeriodEnd",
+      "plan",
+    ]);
+  });
+
+  test("missing provider record is a presence diff", () => {
+    const diffs = diffBillingState(projection, null);
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0].field).toBe("presence");
+  });
+});
+
+describe("decideApply (conservative --apply policy)", () => {
+  const projection = {
+    plan: "premium",
+    status: "active",
+    currentPeriodEnd: FUTURE_S,
+    cancelAtPeriodEnd: false,
+    provider: "stripe",
+  };
+  const providerState = {
+    plan: "premium",
+    status: "past_due",
+    currentPeriodEnd: FUTURE_S,
+    cancelAtPeriodEnd: false,
+  };
+  const someDiff = [{ field: "status", projection: "active", provider: "past_due" }];
+
+  test("in-sync → no apply", () => {
+    expect(decideApply(projection, providerState, [], "stripe").apply).toBe(false);
+  });
+
+  test("same-provider drift → apply", () => {
+    const verdict = decideApply(projection, providerState, someDiff, "stripe");
+    expect(verdict.apply).toBe(true);
+  });
+
+  test("lifetime projection is never auto-corrected", () => {
+    const verdict = decideApply(
+      { ...projection, plan: "lifetime" },
+      providerState,
+      someDiff,
+      "stripe",
+    );
+    expect(verdict.apply).toBe(false);
+    expect(verdict.reason).toContain("lifetime");
+  });
+
+  test("provider-has-no-record is never auto-corrected", () => {
+    const verdict = decideApply(
+      projection,
+      null,
+      [{ field: "presence", projection: "premium/active", provider: "no record" }],
+      "stripe",
+    );
+    expect(verdict.apply).toBe(false);
+    expect(verdict.reason).toContain("no record");
+  });
+
+  test("cross-provider ownership is never auto-corrected", () => {
+    const verdict = decideApply(
+      { ...projection, provider: "apple" },
+      providerState,
+      someDiff,
+      "stripe",
+    );
+    expect(verdict.apply).toBe(false);
+  });
+});

--- a/apps/web/types/supabase.ts
+++ b/apps/web/types/supabase.ts
@@ -362,6 +362,7 @@ export type Database = {
       }
       profile: {
         Row: {
+          billing_provider: string | null
           billing_version: number
           cancel_at_period_end: boolean
           createdAt: string
@@ -377,6 +378,7 @@ export type Database = {
           verified: boolean
         }
         Insert: {
+          billing_provider?: string | null
           billing_version?: number
           cancel_at_period_end?: boolean
           createdAt?: string
@@ -392,6 +394,7 @@ export type Database = {
           verified?: boolean
         }
         Update: {
+          billing_provider?: string | null
           billing_version?: number
           cancel_at_period_end?: boolean
           createdAt?: string
@@ -739,8 +742,10 @@ export type Database = {
         Row: {
           error_message: string | null
           event_id: string
+          event_time_ms: number | null
           event_type: string
           processed_at: string
+          provider: string | null
           retry_count: number
           status: string
           user_id: string | null
@@ -748,8 +753,10 @@ export type Database = {
         Insert: {
           error_message?: string | null
           event_id: string
+          event_time_ms?: number | null
           event_type: string
           processed_at?: string
+          provider?: string | null
           retry_count?: number
           status: string
           user_id?: string | null
@@ -757,8 +764,10 @@ export type Database = {
         Update: {
           error_message?: string | null
           event_id?: string
+          event_time_ms?: number | null
           event_type?: string
           processed_at?: string
+          provider?: string | null
           retry_count?: number
           status?: string
           user_id?: string | null

--- a/apps/web/utils/billing/__tests__/apply-billing-event.test.ts
+++ b/apps/web/utils/billing/__tests__/apply-billing-event.test.ts
@@ -1,0 +1,790 @@
+import { describe, test, expect } from "vitest";
+import {
+  applyBillingEvent,
+  type BillingFact,
+  type BillingProjection,
+  type CurrentBillingState,
+} from "../apply-billing-event";
+import type { BillingProviderId, PlanType } from "@handicappin/billing-core";
+import type { SubscriptionStatus } from "@/lib/stripe-types";
+
+// ---------------------------------------------------------------------------
+// Builders
+// ---------------------------------------------------------------------------
+
+const T0 = 1_750_000_000_000; // arbitrary fixed epoch ms
+const PERIOD_END = 1_780_000_000; // unix seconds, far future
+const LATER_PERIOD_END = PERIOD_END + 86_400 * 30;
+
+let eventCounter = 0;
+
+function fact(overrides: Partial<BillingFact> = {}): BillingFact {
+  eventCounter += 1;
+  return {
+    provider: "apple",
+    plan: "premium",
+    status: "active",
+    currentPeriodEnd: PERIOD_END,
+    cancelAtPeriodEnd: false,
+    eventTimeMs: T0,
+    eventId: `evt_${eventCounter}`,
+    ...overrides,
+  };
+}
+
+function projection(
+  overrides: Partial<BillingProjection> = {},
+): BillingProjection {
+  return {
+    provider: null,
+    plan: null,
+    status: null,
+    currentPeriodEnd: null,
+    cancelAtPeriodEnd: false,
+    ...overrides,
+  };
+}
+
+function state(
+  proj: BillingProjection,
+  lastApplied: CurrentBillingState["lastApplied"] = null,
+): CurrentBillingState {
+  return { projection: proj, lastApplied };
+}
+
+const stripeActivePremium = () =>
+  projection({
+    provider: "stripe",
+    plan: "premium",
+    status: "active",
+    currentPeriodEnd: PERIOD_END,
+  });
+
+const stripeActiveUnlimited = () =>
+  projection({
+    provider: "stripe",
+    plan: "unlimited",
+    status: "active",
+    currentPeriodEnd: PERIOD_END,
+  });
+
+const stripeLifetime = () =>
+  projection({ provider: "stripe", plan: "lifetime", status: "active" });
+
+const freeProjection = () =>
+  projection({ provider: null, plan: "free", status: "active" });
+
+// ---------------------------------------------------------------------------
+// 1. Idempotence
+// ---------------------------------------------------------------------------
+
+describe("idempotence", () => {
+  test("re-delivery of the exact same event id is a no-op", () => {
+    const proj = stripeActivePremium();
+    const incoming = fact({ provider: "stripe", eventId: "evt_dup" });
+    const decision = applyBillingEvent(
+      state(proj, { eventTimeMs: T0, eventId: "evt_dup" }),
+      incoming,
+    );
+    expect(decision.action).toBe("ignore");
+    expect(decision.reason).toBe("idempotent-duplicate");
+    expect(decision.changed).toBe(false);
+    expect(decision.projection).toEqual(proj);
+    expect(decision.alert).toBeNull();
+  });
+
+  test("applying the same fact twice yields no change the second time", () => {
+    const incoming = fact({
+      provider: "apple",
+      plan: "unlimited",
+      eventId: "evt_once",
+    });
+    const first = applyBillingEvent(state(projection()), incoming);
+    expect(first.action).toBe("apply");
+    expect(first.changed).toBe(true);
+
+    // Second application: cursor now points at the same event.
+    const second = applyBillingEvent(
+      state(first.projection, { eventTimeMs: T0, eventId: "evt_once" }),
+      incoming,
+    );
+    expect(second.action).toBe("ignore");
+    expect(second.reason).toBe("idempotent-duplicate");
+    expect(second.projection).toEqual(first.projection);
+  });
+
+  test("re-applying identical state without a cursor applies but reports changed=false", () => {
+    const proj = projection({
+      provider: "apple",
+      plan: "premium",
+      status: "active",
+      currentPeriodEnd: PERIOD_END,
+    });
+    const incoming = fact({ provider: "apple" });
+    const decision = applyBillingEvent(state(proj), incoming);
+    expect(decision.action).toBe("apply");
+    expect(decision.changed).toBe(false);
+    expect(decision.projection).toEqual(proj);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Out-of-order guard
+// ---------------------------------------------------------------------------
+
+describe("per-provider out-of-order guard", () => {
+  test("a fact older than the provider cursor is ignored as stale", () => {
+    const proj = projection({
+      provider: "apple",
+      plan: "premium",
+      status: "active",
+      currentPeriodEnd: PERIOD_END,
+      cancelAtPeriodEnd: true, // user cancelled (newer info)
+    });
+    // Older INITIAL_PURCHASE-shaped fact arrives late.
+    const stale = fact({ provider: "apple", eventTimeMs: T0 - 60_000 });
+    const decision = applyBillingEvent(
+      state(proj, { eventTimeMs: T0, eventId: "evt_newer" }),
+      stale,
+    );
+    expect(decision.action).toBe("ignore");
+    expect(decision.reason).toBe("stale-out-of-order");
+    expect(decision.projection).toEqual(proj);
+  });
+
+  test("an equal-timestamp fact with a different id is NOT stale", () => {
+    const proj = projection({
+      provider: "apple",
+      plan: "premium",
+      status: "active",
+      currentPeriodEnd: PERIOD_END,
+    });
+    const sameMs = fact({
+      provider: "apple",
+      plan: "unlimited",
+      eventTimeMs: T0,
+    });
+    const decision = applyBillingEvent(
+      state(proj, { eventTimeMs: T0, eventId: "evt_other" }),
+      sameMs,
+    );
+    expect(decision.action).toBe("apply");
+    expect(decision.projection.plan).toBe("unlimited");
+  });
+
+  test("no cursor (lastApplied null) skips ordering enforcement", () => {
+    const proj = projection({
+      provider: "apple",
+      plan: "premium",
+      status: "active",
+      currentPeriodEnd: PERIOD_END,
+    });
+    const old = fact({
+      provider: "apple",
+      plan: "unlimited",
+      eventTimeMs: T0 - 999_999,
+    });
+    const decision = applyBillingEvent(state(proj), old);
+    expect(decision.action).toBe("apply");
+  });
+
+  test("staleness wins over idempotence only when ids differ", () => {
+    const proj = stripeActivePremium();
+    const older = fact({
+      provider: "stripe",
+      plan: "unlimited",
+      eventTimeMs: T0 - 1,
+      eventId: "evt_old",
+    });
+    const decision = applyBillingEvent(
+      state(proj, { eventTimeMs: T0, eventId: "evt_new" }),
+      older,
+    );
+    expect(decision.reason).toBe("stale-out-of-order");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Lifetime is absorbing
+// ---------------------------------------------------------------------------
+
+describe("lifetime lock", () => {
+  const lifetimeOwners: BillingProviderId[] = ["stripe", "apple"];
+
+  test.each(lifetimeOwners)(
+    "no event overwrites a %s-owned lifetime",
+    (owner) => {
+      const proj = projection({
+        provider: owner,
+        plan: "lifetime",
+        status: "active",
+      });
+      const attempts: BillingFact[] = [
+        fact({ provider: "stripe", plan: "premium", status: "active" }),
+        fact({ provider: "apple", plan: "unlimited", status: "active" }),
+        fact({ provider: owner, plan: "free", status: "canceled" }), // own EXPIRATION
+        fact({ provider: owner, plan: "premium", status: "past_due" }),
+        fact({ provider: owner, plan: "lifetime", status: "active" }),
+      ];
+      for (const attempt of attempts) {
+        const decision = applyBillingEvent(state(proj), attempt);
+        expect(decision.action).toBe("ignore");
+        expect(decision.reason).toBe("lifetime-locked");
+        expect(decision.projection).toEqual(proj);
+      }
+    },
+  );
+
+  test("cross-provider ACTIVE fact against lifetime raises the double-contract alert", () => {
+    const decision = applyBillingEvent(
+      state(stripeLifetime()),
+      fact({ provider: "apple", plan: "unlimited", status: "active" }),
+    );
+    expect(decision.action).toBe("ignore");
+    expect(decision.alert).not.toBeNull();
+    expect(decision.alert?.kind).toBe("double_contract");
+    expect(decision.alert?.keptProvider).toBe("stripe");
+    expect(decision.alert?.currentPlan).toBe("lifetime");
+    expect(decision.alert?.incomingPlan).toBe("unlimited");
+  });
+
+  test("cross-provider lifetime purchase against lifetime also alerts", () => {
+    const decision = applyBillingEvent(
+      state(stripeLifetime()),
+      fact({ provider: "apple", plan: "lifetime", status: "active" }),
+    );
+    expect(decision.reason).toBe("lifetime-locked");
+    expect(decision.alert?.keptProvider).toBe("stripe");
+  });
+
+  test("same-provider events against lifetime do not alert", () => {
+    const decision = applyBillingEvent(
+      state(stripeLifetime()),
+      fact({ provider: "stripe", plan: "premium", status: "active" }),
+    );
+    expect(decision.reason).toBe("lifetime-locked");
+    expect(decision.alert).toBeNull();
+  });
+
+  test("cross-provider INACTIVE fact against lifetime does not alert", () => {
+    const decision = applyBillingEvent(
+      state(stripeLifetime()),
+      fact({ provider: "apple", plan: "premium", status: "past_due" }),
+    );
+    expect(decision.reason).toBe("lifetime-locked");
+    expect(decision.alert).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Initial application (no attributed contract)
+// ---------------------------------------------------------------------------
+
+describe("initial application", () => {
+  test("first paid fact lands verbatim on a never-paid profile", () => {
+    const decision = applyBillingEvent(
+      state(projection()),
+      fact({
+        provider: "apple",
+        plan: "premium",
+        status: "active",
+        currentPeriodEnd: PERIOD_END,
+      }),
+    );
+    expect(decision.action).toBe("apply");
+    expect(decision.reason).toBe("initial");
+    expect(decision.projection).toEqual({
+      provider: "apple",
+      plan: "premium",
+      status: "active",
+      currentPeriodEnd: PERIOD_END,
+      cancelAtPeriodEnd: false,
+    });
+  });
+
+  test("first paid fact lands on a free-tier profile (provider null)", () => {
+    const decision = applyBillingEvent(
+      state(freeProjection()),
+      fact({ provider: "apple", plan: "unlimited", status: "active" }),
+    );
+    expect(decision.action).toBe("apply");
+    expect(decision.projection.plan).toBe("unlimited");
+    expect(decision.projection.provider).toBe("apple");
+  });
+
+  test("a non-active fact also lands when there is no contract to defend", () => {
+    // e.g. CANCELLATION arrives before the (lost) INITIAL_PURCHASE: the user
+    // is entitled until period end, matching web's canceled+grace semantics.
+    const decision = applyBillingEvent(
+      state(projection()),
+      fact({
+        provider: "apple",
+        plan: "premium",
+        status: "active",
+        cancelAtPeriodEnd: true,
+        currentPeriodEnd: PERIOD_END,
+      }),
+    );
+    expect(decision.action).toBe("apply");
+    expect(decision.projection.cancelAtPeriodEnd).toBe(true);
+  });
+
+  test("lifetime fact normalizes period fields", () => {
+    const decision = applyBillingEvent(
+      state(projection()),
+      fact({
+        provider: "apple",
+        plan: "lifetime",
+        status: "active",
+        currentPeriodEnd: PERIOD_END, // bogus input — must be cleared
+        cancelAtPeriodEnd: true, // bogus input — must be cleared
+      }),
+    );
+    expect(decision.projection).toEqual({
+      provider: "apple",
+      plan: "lifetime",
+      status: "active",
+      currentPeriodEnd: null,
+      cancelAtPeriodEnd: false,
+    });
+  });
+
+  test("free fact clears contract metadata (provider, period, cap)", () => {
+    const decision = applyBillingEvent(
+      state(projection()),
+      fact({
+        provider: "apple",
+        plan: "free",
+        status: "canceled",
+        currentPeriodEnd: PERIOD_END,
+        cancelAtPeriodEnd: true,
+      }),
+    );
+    expect(decision.projection).toEqual({
+      provider: null,
+      plan: "free",
+      status: "canceled",
+      currentPeriodEnd: null,
+      cancelAtPeriodEnd: false,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Same-provider lifecycle (provider owns its own contract)
+// ---------------------------------------------------------------------------
+
+describe("same-provider lifecycle", () => {
+  test("renewal extends the period", () => {
+    const proj = projection({
+      provider: "apple",
+      plan: "premium",
+      status: "active",
+      currentPeriodEnd: PERIOD_END,
+    });
+    const decision = applyBillingEvent(
+      state(proj),
+      fact({
+        provider: "apple",
+        plan: "premium",
+        currentPeriodEnd: LATER_PERIOD_END,
+      }),
+    );
+    expect(decision.action).toBe("apply");
+    expect(decision.reason).toBe("same-provider-update");
+    expect(decision.projection.currentPeriodEnd).toBe(LATER_PERIOD_END);
+  });
+
+  test("upgrade applies (premium → unlimited)", () => {
+    const decision = applyBillingEvent(
+      state(
+        projection({
+          provider: "apple",
+          plan: "premium",
+          status: "active",
+          currentPeriodEnd: PERIOD_END,
+        }),
+      ),
+      fact({ provider: "apple", plan: "unlimited" }),
+    );
+    expect(decision.projection.plan).toBe("unlimited");
+  });
+
+  test("downgrade applies (unlimited → premium) — the provider is source of truth for its contract", () => {
+    const decision = applyBillingEvent(
+      state(
+        projection({
+          provider: "apple",
+          plan: "unlimited",
+          status: "active",
+          currentPeriodEnd: PERIOD_END,
+        }),
+      ),
+      fact({ provider: "apple", plan: "premium" }),
+    );
+    expect(decision.action).toBe("apply");
+    expect(decision.projection.plan).toBe("premium");
+  });
+
+  test("cancellation sets cancel_at_period_end without dropping entitlement", () => {
+    const decision = applyBillingEvent(
+      state(
+        projection({
+          provider: "apple",
+          plan: "premium",
+          status: "active",
+          currentPeriodEnd: PERIOD_END,
+        }),
+      ),
+      fact({
+        provider: "apple",
+        plan: "premium",
+        status: "active",
+        cancelAtPeriodEnd: true,
+      }),
+    );
+    expect(decision.projection.cancelAtPeriodEnd).toBe(true);
+    expect(decision.projection.plan).toBe("premium");
+    expect(decision.projection.status).toBe("active");
+  });
+
+  test("uncancellation clears cancel_at_period_end", () => {
+    const decision = applyBillingEvent(
+      state(
+        projection({
+          provider: "apple",
+          plan: "premium",
+          status: "active",
+          currentPeriodEnd: PERIOD_END,
+          cancelAtPeriodEnd: true,
+        }),
+      ),
+      fact({ provider: "apple", plan: "premium", cancelAtPeriodEnd: false }),
+    );
+    expect(decision.projection.cancelAtPeriodEnd).toBe(false);
+  });
+
+  test("billing issue moves status to past_due", () => {
+    const decision = applyBillingEvent(
+      state(
+        projection({
+          provider: "apple",
+          plan: "unlimited",
+          status: "active",
+          currentPeriodEnd: PERIOD_END,
+        }),
+      ),
+      fact({ provider: "apple", plan: "unlimited", status: "past_due" }),
+    );
+    expect(decision.projection.status).toBe("past_due");
+    expect(decision.projection.provider).toBe("apple");
+  });
+
+  test("expiration reverts to free and clears the provider", () => {
+    const decision = applyBillingEvent(
+      state(
+        projection({
+          provider: "apple",
+          plan: "premium",
+          status: "active",
+          currentPeriodEnd: PERIOD_END,
+        }),
+      ),
+      fact({
+        provider: "apple",
+        plan: "free",
+        status: "canceled",
+        currentPeriodEnd: null,
+      }),
+    );
+    expect(decision.projection).toEqual({
+      provider: null,
+      plan: "free",
+      status: "canceled",
+      currentPeriodEnd: null,
+      cancelAtPeriodEnd: false,
+    });
+  });
+
+  test("recovery from past_due applies (renewal after billing issue)", () => {
+    const decision = applyBillingEvent(
+      state(
+        projection({
+          provider: "apple",
+          plan: "unlimited",
+          status: "past_due",
+          currentPeriodEnd: PERIOD_END,
+        }),
+      ),
+      fact({
+        provider: "apple",
+        plan: "unlimited",
+        status: "active",
+        currentPeriodEnd: LATER_PERIOD_END,
+      }),
+    );
+    expect(decision.projection.status).toBe("active");
+    expect(decision.projection.currentPeriodEnd).toBe(LATER_PERIOD_END);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Cross-provider arbitration
+// ---------------------------------------------------------------------------
+
+describe("cross-provider: active beats non-active", () => {
+  const deadStates: Array<Partial<BillingProjection>> = [
+    { status: "past_due" },
+    { status: "canceled", cancelAtPeriodEnd: true },
+    { status: "unpaid" },
+    { status: "incomplete" },
+    { status: "paused" },
+  ];
+
+  test.each(deadStates)(
+    "incoming apple-active displaces a dead stripe contract (%o)",
+    (dead) => {
+      const proj = projection({
+        provider: "stripe",
+        plan: "premium",
+        currentPeriodEnd: PERIOD_END,
+        ...dead,
+      });
+      const decision = applyBillingEvent(
+        state(proj),
+        fact({ provider: "apple", plan: "premium", status: "active" }),
+      );
+      expect(decision.action).toBe("apply");
+      expect(decision.reason).toBe("active-beats-inactive");
+      expect(decision.projection.provider).toBe("apple");
+      expect(decision.alert).toBeNull();
+    },
+  );
+
+  test("incoming stripe-active displaces a dead apple contract", () => {
+    const proj = projection({
+      provider: "apple",
+      plan: "unlimited",
+      status: "past_due",
+      currentPeriodEnd: PERIOD_END,
+    });
+    const decision = applyBillingEvent(
+      state(proj),
+      fact({ provider: "stripe", plan: "premium", status: "active" }),
+    );
+    expect(decision.action).toBe("apply");
+    expect(decision.projection.provider).toBe("stripe");
+    expect(decision.projection.plan).toBe("premium");
+  });
+
+  test("an inactive fact about the OTHER provider's contract is ignored", () => {
+    // stripe-active user; apple says some apple contract expired. Irrelevant.
+    const proj = stripeActivePremium();
+    const decision = applyBillingEvent(
+      state(proj),
+      fact({ provider: "apple", plan: "free", status: "canceled" }),
+    );
+    expect(decision.action).toBe("ignore");
+    expect(decision.reason).toBe("inactive-foreign-contract");
+    expect(decision.projection).toEqual(proj);
+    expect(decision.alert).toBeNull();
+  });
+
+  test("two dead contracts: current stands", () => {
+    const proj = projection({
+      provider: "stripe",
+      plan: "premium",
+      status: "past_due",
+      currentPeriodEnd: PERIOD_END,
+    });
+    const decision = applyBillingEvent(
+      state(proj),
+      fact({ provider: "apple", plan: "premium", status: "past_due" }),
+    );
+    expect(decision.action).toBe("ignore");
+    expect(decision.reason).toBe("inactive-foreign-contract");
+  });
+});
+
+describe("cross-provider: double contract (both active)", () => {
+  test("higher incoming tier wins and alerts (stripe premium vs apple unlimited)", () => {
+    const decision = applyBillingEvent(
+      state(stripeActivePremium()),
+      fact({ provider: "apple", plan: "unlimited", status: "active" }),
+    );
+    expect(decision.action).toBe("apply");
+    expect(decision.reason).toBe("double-contract-incoming-wins");
+    expect(decision.projection.provider).toBe("apple");
+    expect(decision.projection.plan).toBe("unlimited");
+    expect(decision.alert).toEqual({
+      kind: "double_contract",
+      currentProvider: "stripe",
+      incomingProvider: "apple",
+      currentPlan: "premium",
+      incomingPlan: "unlimited",
+      keptProvider: "apple",
+      eventId: decision.alert?.eventId,
+    });
+  });
+
+  test("higher current tier stands and alerts (stripe unlimited vs apple premium)", () => {
+    const proj = stripeActiveUnlimited();
+    const decision = applyBillingEvent(
+      state(proj),
+      fact({ provider: "apple", plan: "premium", status: "active" }),
+    );
+    expect(decision.action).toBe("ignore");
+    expect(decision.reason).toBe("double-contract-current-wins");
+    expect(decision.projection).toEqual(proj);
+    expect(decision.alert?.keptProvider).toBe("stripe");
+  });
+
+  test("equal tier: later expiry wins (incoming later)", () => {
+    const decision = applyBillingEvent(
+      state(stripeActivePremium()),
+      fact({
+        provider: "apple",
+        plan: "premium",
+        status: "active",
+        currentPeriodEnd: LATER_PERIOD_END,
+      }),
+    );
+    expect(decision.action).toBe("apply");
+    expect(decision.reason).toBe("double-contract-incoming-wins");
+    expect(decision.projection.currentPeriodEnd).toBe(LATER_PERIOD_END);
+    expect(decision.alert).not.toBeNull();
+  });
+
+  test("equal tier: earlier incoming expiry loses", () => {
+    const proj = projection({
+      provider: "stripe",
+      plan: "premium",
+      status: "active",
+      currentPeriodEnd: LATER_PERIOD_END,
+    });
+    const decision = applyBillingEvent(
+      state(proj),
+      fact({
+        provider: "apple",
+        plan: "premium",
+        status: "active",
+        currentPeriodEnd: PERIOD_END,
+      }),
+    );
+    expect(decision.action).toBe("ignore");
+    expect(decision.reason).toBe("double-contract-current-wins");
+    expect(decision.alert).not.toBeNull();
+  });
+
+  test("exact tie keeps the current contract (no flapping)", () => {
+    const decision = applyBillingEvent(
+      state(stripeActivePremium()),
+      fact({
+        provider: "apple",
+        plan: "premium",
+        status: "active",
+        currentPeriodEnd: PERIOD_END,
+      }),
+    );
+    expect(decision.action).toBe("ignore");
+    expect(decision.reason).toBe("double-contract-current-wins");
+  });
+
+  test("incoming apple lifetime purchase beats an active stripe sub and alerts", () => {
+    const decision = applyBillingEvent(
+      state(stripeActiveUnlimited()),
+      fact({
+        provider: "apple",
+        plan: "lifetime",
+        status: "active",
+        currentPeriodEnd: null,
+      }),
+    );
+    expect(decision.action).toBe("apply");
+    expect(decision.projection.plan).toBe("lifetime");
+    expect(decision.projection.provider).toBe("apple");
+    expect(decision.alert?.keptProvider).toBe("apple");
+  });
+
+  test("trialing counts as active on both sides", () => {
+    const proj = projection({
+      provider: "stripe",
+      plan: "premium",
+      status: "trialing",
+      currentPeriodEnd: PERIOD_END,
+    });
+    const decision = applyBillingEvent(
+      state(proj),
+      fact({ provider: "apple", plan: "premium", status: "trialing" }),
+    );
+    expect(decision.reason).toBe("double-contract-current-wins");
+    expect(decision.alert).not.toBeNull();
+  });
+
+  test("never auto-cancels: losing decision leaves the other contract untouched", () => {
+    // The decision only ever returns a projection — there is no side channel
+    // that could cancel anything. Assert the losing fact changes nothing.
+    const proj = stripeActiveUnlimited();
+    const decision = applyBillingEvent(
+      state(proj),
+      fact({ provider: "apple", plan: "premium", status: "active" }),
+    );
+    expect(decision.projection).toEqual(proj);
+    expect(decision.changed).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Full precedence matrix (programmatic sweep)
+// ---------------------------------------------------------------------------
+
+describe("precedence matrix sweep", () => {
+  const tiers: PlanType[] = ["premium", "unlimited"];
+  const statuses: SubscriptionStatus[] = ["active", "past_due", "canceled"];
+
+  for (const curPlan of tiers) {
+    for (const curStatus of statuses) {
+      for (const inPlan of tiers) {
+        for (const inStatus of statuses) {
+          const curActive = curStatus === "active";
+          const inActive = inStatus === "active";
+          test(`stripe ${curPlan}/${curStatus} vs apple ${inPlan}/${inStatus}`, () => {
+            const proj = projection({
+              provider: "stripe",
+              plan: curPlan,
+              status: curStatus,
+              currentPeriodEnd: PERIOD_END,
+            });
+            const decision = applyBillingEvent(
+              state(proj),
+              fact({
+                provider: "apple",
+                plan: inPlan,
+                status: inStatus,
+                currentPeriodEnd: PERIOD_END,
+              }),
+            );
+
+            if (curActive && inActive) {
+              // Double contract: tier decides (equal tier + equal expiry → current).
+              const inWins =
+                (inPlan === "unlimited" ? 2 : 1) >
+                (curPlan === "unlimited" ? 2 : 1);
+              expect(decision.action).toBe(inWins ? "apply" : "ignore");
+              expect(decision.alert?.kind).toBe("double_contract");
+            } else if (!curActive && inActive) {
+              expect(decision.action).toBe("apply");
+              expect(decision.reason).toBe("active-beats-inactive");
+              expect(decision.alert).toBeNull();
+            } else {
+              // Incoming inactive never displaces a foreign contract.
+              expect(decision.action).toBe("ignore");
+              expect(decision.reason).toBe("inactive-foreign-contract");
+              expect(decision.alert).toBeNull();
+            }
+          });
+        }
+      }
+    }
+  }
+});

--- a/apps/web/utils/billing/apply-billing-event.ts
+++ b/apps/web/utils/billing/apply-billing-event.ts
@@ -1,0 +1,277 @@
+/**
+ * THE cross-provider merge chokepoint (decision ledger D-precedence).
+ *
+ * Every webhook-driven write to the profile's billing projection — Stripe
+ * or RevenueCat/Apple — is decided here, as a pure function over normalized
+ * facts. The DB is the single source of truth for ENTITLEMENT; each provider
+ * is the source of truth only for the contract IT bills (D-arch), so:
+ *
+ *   1. lifetime is never overwritten by any event;
+ *   2. a provider's own facts replace its own contract state verbatim;
+ *   3. across providers: active beats non-active; between actives the
+ *      higher tier wins (lifetime > unlimited > premium > free), then the
+ *      later expiry; ties keep the current contract;
+ *   4. per-provider ordering: facts older than the last evaluated fact
+ *      from the same provider are ignored (the caller supplies the cursor);
+ *   5. double-contract (both providers active): keep max entitlement,
+ *      surface an admin alert, NEVER auto-cancel the other provider.
+ *
+ * Units: `currentPeriodEnd` is unix SECONDS (the profile column);
+ * `eventTimeMs` is epoch MILLISECONDS (providers' own event clocks).
+ */
+import type { BillingProviderId, PlanType } from "@handicappin/billing-core";
+import { planRank } from "@handicappin/billing-core";
+import type { SubscriptionStatus } from "@/lib/stripe-types";
+
+/** A provider's claim about the contract it bills, normalized. */
+export interface BillingFact {
+  provider: BillingProviderId;
+  plan: PlanType | null;
+  status: SubscriptionStatus | null;
+  /** Unix seconds; null when not applicable (lifetime / no contract). */
+  currentPeriodEnd: number | null;
+  cancelAtPeriodEnd: boolean;
+  /** The provider's own event timestamp (epoch ms) — orders same-provider facts. */
+  eventTimeMs: number;
+  /** The provider's event id — idempotence key. */
+  eventId: string;
+}
+
+/** The billing slice of the profile row (the stored projection). */
+export interface BillingProjection {
+  provider: BillingProviderId | null;
+  plan: PlanType | null;
+  status: SubscriptionStatus | null;
+  currentPeriodEnd: number | null;
+  cancelAtPeriodEnd: boolean;
+}
+
+/** What the caller knows before merging: the projection + the provider cursor. */
+export interface CurrentBillingState {
+  projection: BillingProjection;
+  /**
+   * Last successfully EVALUATED event from the INCOMING fact's provider
+   * (webhook_events cursor), or null to skip ordering enforcement — the
+   * Stripe handlers pass null to preserve their existing semantics.
+   */
+  lastApplied: { eventTimeMs: number; eventId: string } | null;
+}
+
+export interface DoubleContractAlert {
+  kind: "double_contract";
+  currentProvider: BillingProviderId;
+  incomingProvider: BillingProviderId;
+  currentPlan: PlanType | null;
+  incomingPlan: PlanType | null;
+  keptProvider: BillingProviderId;
+  eventId: string;
+}
+
+export type ApplyReason =
+  | "initial" // no current contract — fact lands verbatim
+  | "same-provider-update" // provider updated its own contract
+  | "active-beats-inactive" // cross-provider: active fact displaces dead contract
+  | "double-contract-incoming-wins" // both active; incoming is max entitlement
+  | "double-contract-current-wins" // both active; current is max entitlement
+  | "idempotent-duplicate" // same eventId as last applied
+  | "stale-out-of-order" // older than the provider cursor
+  | "lifetime-locked" // current plan is lifetime — absorbing state
+  | "inactive-foreign-contract"; // other provider's dead contract — irrelevant
+
+export interface ApplyDecision {
+  action: "apply" | "ignore";
+  reason: ApplyReason;
+  /** The resulting projection (=== input projection content when ignoring). */
+  projection: BillingProjection;
+  /** True iff action==="apply" AND the projection materially differs. */
+  changed: boolean;
+  alert: DoubleContractAlert | null;
+}
+
+const ACTIVE_STATUSES: ReadonlySet<SubscriptionStatus> = new Set([
+  "active",
+  "trialing",
+]);
+
+function isPaidPlan(plan: PlanType | null): boolean {
+  return plan === "premium" || plan === "unlimited" || plan === "lifetime";
+}
+
+/** An ACTIVE CONTRACT: a paid plan that is lifetime or currently billing. */
+function isActiveContract(c: {
+  plan: PlanType | null;
+  status: SubscriptionStatus | null;
+}): boolean {
+  if (!isPaidPlan(c.plan)) return false;
+  if (c.plan === "lifetime") return true;
+  return c.status !== null && ACTIVE_STATUSES.has(c.status);
+}
+
+/**
+ * Normalize a fact into the projection it would produce if applied.
+ * A fact that ends entitlement (plan free/null) clears the contract
+ * metadata — mirroring the existing subscription.deleted write.
+ */
+function projectionFromFact(fact: BillingFact): BillingProjection {
+  if (!isPaidPlan(fact.plan)) {
+    return {
+      provider: null,
+      plan: fact.plan ?? null,
+      status: fact.status,
+      currentPeriodEnd: null,
+      cancelAtPeriodEnd: false,
+    };
+  }
+  return {
+    provider: fact.provider,
+    plan: fact.plan,
+    status: fact.status,
+    currentPeriodEnd: fact.plan === "lifetime" ? null : fact.currentPeriodEnd,
+    cancelAtPeriodEnd: fact.plan === "lifetime" ? false : fact.cancelAtPeriodEnd,
+  };
+}
+
+function projectionsEqual(a: BillingProjection, b: BillingProjection): boolean {
+  return (
+    a.provider === b.provider &&
+    a.plan === b.plan &&
+    a.status === b.status &&
+    a.currentPeriodEnd === b.currentPeriodEnd &&
+    a.cancelAtPeriodEnd === b.cancelAtPeriodEnd
+  );
+}
+
+/** Higher tier wins; equal tiers fall back to later expiry; tie → current. */
+function incomingBeatsCurrentAmongActives(
+  current: BillingProjection,
+  incoming: BillingFact,
+): boolean {
+  const rankDelta = planRank(incoming.plan) - planRank(current.plan);
+  if (rankDelta !== 0) return rankDelta > 0;
+  const currentEnd = current.currentPeriodEnd ?? 0;
+  const incomingEnd = incoming.currentPeriodEnd ?? 0;
+  return incomingEnd > currentEnd;
+}
+
+function ignore(
+  projection: BillingProjection,
+  reason: ApplyReason,
+  alert: DoubleContractAlert | null = null,
+): ApplyDecision {
+  return { action: "ignore", reason, projection, changed: false, alert };
+}
+
+function apply(
+  current: BillingProjection,
+  incoming: BillingFact,
+  reason: ApplyReason,
+  alert: DoubleContractAlert | null = null,
+): ApplyDecision {
+  const next = projectionFromFact(incoming);
+  return {
+    action: "apply",
+    reason,
+    projection: next,
+    changed: !projectionsEqual(current, next),
+    alert,
+  };
+}
+
+function doubleContractAlert(
+  current: BillingProjection,
+  incoming: BillingFact,
+  keptProvider: BillingProviderId,
+): DoubleContractAlert {
+  return {
+    kind: "double_contract",
+    // current.provider is non-null on every double-contract path
+    currentProvider: current.provider as BillingProviderId,
+    incomingProvider: incoming.provider,
+    currentPlan: current.plan,
+    incomingPlan: incoming.plan,
+    keptProvider,
+    eventId: incoming.eventId,
+  };
+}
+
+/**
+ * Decide what an incoming billing fact does to the stored projection.
+ * Pure — no I/O, no clock, no randomness. The caller persists
+ * `decision.projection` (and bumps billing_version) iff `decision.changed`,
+ * and routes `decision.alert` to admin alerting.
+ */
+export function applyBillingEvent(
+  current: CurrentBillingState,
+  incoming: BillingFact,
+): ApplyDecision {
+  const { projection, lastApplied } = current;
+
+  // 1. Idempotence: the exact same event re-delivered is a no-op.
+  if (lastApplied !== null && lastApplied.eventId === incoming.eventId) {
+    return ignore(projection, "idempotent-duplicate");
+  }
+
+  // 2. Per-provider ordering: never let an older fact rewind newer state.
+  if (lastApplied !== null && incoming.eventTimeMs < lastApplied.eventTimeMs) {
+    return ignore(projection, "stale-out-of-order");
+  }
+
+  // 3. Lifetime is absorbing — no event overwrites it. Still surface the
+  //    double-pay alert when ANOTHER provider claims an active contract.
+  if (projection.plan === "lifetime") {
+    const crossProviderActive =
+      projection.provider !== null &&
+      incoming.provider !== projection.provider &&
+      isActiveContract(incoming);
+    return ignore(
+      projection,
+      "lifetime-locked",
+      crossProviderActive
+        ? doubleContractAlert(projection, incoming, projection.provider as BillingProviderId)
+        : null,
+    );
+  }
+
+  // 4. No attributed contract yet (never paid, or reverted to free):
+  //    the fact lands verbatim.
+  if (projection.provider === null) {
+    return apply(projection, incoming, "initial");
+  }
+
+  // 5. A provider's own facts replace its own contract state — it is the
+  //    source of truth for the contract it bills (D-arch).
+  if (incoming.provider === projection.provider) {
+    return apply(projection, incoming, "same-provider-update");
+  }
+
+  // 6. Cross-provider arbitration.
+  const currentActive = isActiveContract(projection);
+  const incomingActive = isActiveContract(incoming);
+
+  if (currentActive && incomingActive) {
+    // Double contract: keep max entitlement, alert, never auto-cancel.
+    if (incomingBeatsCurrentAmongActives(projection, incoming)) {
+      return apply(
+        projection,
+        incoming,
+        "double-contract-incoming-wins",
+        doubleContractAlert(projection, incoming, incoming.provider),
+      );
+    }
+    return ignore(
+      projection,
+      "double-contract-current-wins",
+      doubleContractAlert(projection, incoming, projection.provider),
+    );
+  }
+
+  if (incomingActive) {
+    // Current contract is dead (canceled/past_due/...) — the new provider's
+    // active contract takes over.
+    return apply(projection, incoming, "active-beats-inactive");
+  }
+
+  // Incoming describes the OTHER provider's inactive contract — it says
+  // nothing about the contract that owns the projection.
+  return ignore(projection, "inactive-foreign-contract");
+}

--- a/docs/billing-implementation-log.md
+++ b/docs/billing-implementation-log.md
@@ -1,0 +1,40 @@
+# Billing Implementation Log
+
+Running record for the cross-platform billing goal
+(docs/billing-implementation-handoff.md): every decision made under the
+autonomy protocol (§0b), every waiver, anything deferred. D-numbering
+continues from docs/native-implementation-log.md (starts at D22).
+
+## Decisions
+
+### D22 — Shared SKU/plan constants live in a new source-only workspace package (2026-06-12)
+
+**What:** `packages/billing-core` (`@handicappin/billing-core`), modeled 1:1
+on `@handicappin/handicap-core` (source-entry TS package, no build step).
+Holds the D-products SKU constants (`com.handicappin.premium.yearly`,
+`com.handicappin.unlimited.yearly`, `com.handicappin.lifetime`), the
+SKU↔plan mapping, RC entitlement identifiers, the subscription-group id,
+and the plan tier ranking (lifetime > unlimited > premium > free) used by
+the precedence rules.
+
+**Why:** the handoff requires the mapping in ONE module used by webhook
+mapping, runbook, and native code. The apps cannot import each other
+(native log D1 — colliding `@/*` aliases), so "one module" must be a
+workspace package; handicap-core proves the pattern works in both the
+Next and Metro bundlers.
+
+**Alternatives rejected:** duplicating constants per app (drift risk —
+exactly what the ledger forbids); putting them in `packages/handicap-core`
+(wrong domain); putting them web-side only (native can't import).
+
+## Waivers
+
+(none yet)
+
+## Deferred
+
+(none yet)
+
+## Per-state paywall evidence
+
+(populated during cluster 8)

--- a/docs/billing-implementation-log.md
+++ b/docs/billing-implementation-log.md
@@ -141,6 +141,31 @@ expo-web-browser (`SITE_URL/profile/<uid>`). Not an owner gap.
 
 (none yet)
 
-## Per-state paywall evidence
+## Per-state paywall evidence (2026-06-12, DoD #9)
 
-(populated during cluster 8)
+Method: profile driven through each state — SQL in the exact webhook write
+shape for the stripe/free/null states (D15 pattern), and REAL RC-shaped
+POSTs to the LOCAL webhook (`/api/webhooks/revenuecat`, dev-mode auth
+skip) for every apple state, so the on-sim verification exercised the full
+pipeline: webhook → applyBillingEvent → projection → tRPC → paywall.
+Flows live in `apps/native/.maestro/billing-states/` (kept OUT of
+`.maestro/flows/` — they assume driven states, the main suite assumes the
+test account's resting state). Captures in /tmp/handicappin-billing-states/.
+All judgments in-band (vision) against the §1 matrix + design language.
+
+| State | Driven by | Maestro | Capture(s) | In-band verdict |
+|---|---|---|---|---|
+| plan NULL → onboarding | SQL + fresh sign-in | state-null-onboarding.yaml PASS (+ the original onboarding.yaml PASS — its plan-less prerequisite finally held) | null-onboarding-{top,mock-notice,disclosure}.png | PASS — full paywall: real pricing cards w/ live promo data (93 slots), paid CTA → labelled dev notice (mock seam), Restore button, full 3.1.2 disclosure + Terms/Privacy links |
+| plan free (profile) | SQL | state-free.yaml PASS | free-{paywall,mock-notice,restore}.png | PASS — "Free Plan / 18 rounds remaining", purchasable real lineup ($19/yr, $29/yr, $149 one-time) w/ Subscribe buttons, mock notice on buy, disclosure, Restore; no neutral copy |
+| stripe + premium + active | SQL (webhook shape) | state-stripe-active.yaml PASS | stripe-premium-active.png | PASS — "Renews on June 14, 2027", neutral "managed on handicappin.com" as plain muted TEXT (no link — D-policy), NO purchase/plan-change/manage buttons, Restore present |
+| apple + unlimited + active | REAL INITIAL_PURCHASE webhook (route correctly flagged double-contract vs the seeded stripe-active and kept max entitlement) | state-apple-active.yaml PASS | apple-unlimited-active.png | PASS — primary "Switch to Premium" (group plan change), "Manage Subscription (App Store)", Restore, renews line |
+| apple + cancel_at_period_end | REAL CANCELLATION webhook | state-apple-cap.yaml PASS | apple-cancel-at-period-end.png | PASS — "Cancels on June 14, 2027", plan change + manage remain (still active until period end) |
+| apple + past_due | REAL UNCANCELLATION + BILLING_ISSUE webhooks | state-past-due.yaml PASS | apple-past-due.png | PASS — destructive "Payment issue — please update your payment method.", manage + Restore, NO plan change, NO purchase buttons (D26) |
+| lifetime (apple) | REAL NON_RENEWING_PURCHASE webhook | state-lifetime.yaml PASS | lifetime.png | PASS — "✓ Lifetime Access", "No subscription management needed", Restore only |
+
+**Restoration:** test account reset to the original
+unlimited/active/stripe shape (`current_period_end` NULL,
+`cancel_at_period_end` false, billing_version bumped), the sim-verify
+webhook_events rows deleted (no stale apple cursor), and re-verified
+END-TO-END: sign-out → sign-in (fresh JWT) → the standard profile.yaml
+flow PASS ("Unlimited Plan" + mocked-restore notice).

--- a/docs/billing-implementation-log.md
+++ b/docs/billing-implementation-log.md
@@ -83,6 +83,56 @@ recorded queryably in the success row's `error_message`
 Sentry alert — integration tests assert the recorded note, and operators
 can audit alerts without Sentry access.
 
+### D25 — Native seam: lazy-required SDK module, pure selection rule, real lineup prices (2026-06-12)
+
+**What:** `lib/billing/index.ts` selects the provider via
+`selectBillingProviderKind(env.revenueCatIosApiKey)` (pure module, unit
+tested). The real `RevenueCatBillingProvider` lives in its own module and
+is `require`d ONLY inside the key-present branch — a key-less app (CI,
+sim verification) never evaluates the SDK module, so the app boots even
+if the native module were absent. The SDK is wrapped behind pure
+structural mapping (`revenuecat-mapping.ts`, unit tested in node);
+`configure()` runs `Purchases.configure({apiKey})` once + `logIn(supabase
+userId)` per session (D-rc-scope). Mock offerings now carry the REAL
+D-products lineup (premium $19/yr, unlimited $29/yr, lifetime $149 — the
+monthly placeholder is gone) with truthful price strings; only the
+purchase FLOW is mocked, and it still says so via the labelled dev notice.
+
+**Why:** D-seam requires "the SDK must never be configured without a key"
+and a mock-driven app that passes the full Maestro suite key-less. Lazy
+evaluation + the constructor throw + factory guard give three layers.
+Price strings stopped being labelled "(mock)" because they now state the
+real lineup's real prices — the mock label belongs on the FLOW (the dev
+notice), not on truthful catalog data.
+
+### D26 — Paywall policy: non-active paid contracts show management, never purchase buttons (2026-06-12)
+
+**What:** `paywallPolicyFor` implements the LOCKED §1 matrix and extends
+it to the states the matrix doesn't enumerate: `past_due` and
+canceled-in-grace keep their owning provider's affordance (apple → manage
+link, no plan change while not active; stripe → neutral copy) and never
+show purchase buttons. Legacy paid rows with `billing_provider` NULL are
+treated as stripe-billed (every pre-existing paid contract is Stripe's —
+same rationale as the migration backfill). Onboarding remains the
+plan-null full paywall; paid CTAs purchase through the seam, free-tier
+selection and the EARLY100 promo claim keep the dev notice pointing at
+the website (web server flows, unreachable from native — D10 carry-over).
+Restore is on both surfaces; the auto-renew disclosure + Terms/Privacy
+links render wherever purchase buttons can appear (App Store 3.1.2).
+
+**Why:** buying while a contract exists double-bills (the exact failure
+D-precedence's double-contract alert exists to catch — the UI shouldn't
+manufacture that case); a past-due user's fix is updating payment, which
+lives with the owning provider.
+
+**Compliance note (DoD #10):** web HAS a real account-deletion flow
+(`apps/web/components/profile/account-deletion-section.tsx` on the
+profile settings tab → `server/api/routers/account.ts`: OTP-confirmed,
+cancels Stripe subscriptions, deletes auth user + data). The native
+Settings tab now has an explicit "Delete Account" entry (App Store
+5.1.1(v)) that explains the consequence and opens that surface via
+expo-web-browser (`SITE_URL/profile/<uid>`). Not an owner gap.
+
 ## Waivers
 
 (none yet)

--- a/docs/billing-implementation-log.md
+++ b/docs/billing-implementation-log.md
@@ -133,13 +133,51 @@ Settings tab now has an explicit "Delete Account" entry (App Store
 5.1.1(v)) that explains the consequence and opens that surface via
 expo-web-browser (`SITE_URL/profile/<uid>`). Not an owner gap.
 
+## Final gate sweep (2026-06-12, DoD #12)
+
+- pnpm parity (theme-drift + routes + styles) ✓ · check:tokens ✓ ·
+  check:schema-sync ✓
+- web: lint ✓ (0 errors; the one pre-existing add-course-dialog warning,
+  untouched) · tsc ✓ · **644/644 tests** (506 pre-existing + 78
+  applyBillingEvent + 24 reconcile-core + 26 RC-webhook integration + 10
+  stripe-guard integration; integration suites run against the REAL local
+  Supabase) · production build ✓
+- tokens: 37/37 ✓
+- native: tsc ✓ · lint ✓ · unit **60/60** (+13 paywall-policy/seam, +5
+  RC mapping) · verify:harness 55/55 ✓ · expo export -p ios ✓ ·
+  expo prebuild --no-install ✓ (added the android package id to app.json —
+  committed)
+- Maestro with NO RevenueCat key (the D-seam proof): **16/16 existing
+  flows PASS** on the rebuilt dev client (react-native-purchases native
+  module installed; mock provider active) + the 7 per-state billing flows
+- reconcile-billing dry-run: clean execution against the local stack +
+  live Stripe TEST API (caught real period-end drift on an owner account —
+  reported, correctly not auto-applied)
+
 ## Waivers
 
-(none yet)
+(none)
 
 ## Deferred
 
-(none yet)
+- **--apply path of reconcile-billing against live RC data** — implemented
+  conservatively + unit-tested, but only exercisable once
+  REVENUECAT_API_KEY exists (owner console work; runbook §4 step 9).
+- **Real-SDK purchase paths on device** — the RevenueCatBillingProvider
+  compiles and is structurally tested; actually exercising StoreKit needs
+  the owner's App Store Connect products + TestFlight (runbook §4). The
+  mock path is fully verified on-sim.
+- **Apple lifetime refund auto-revocation** — deliberately NOT implemented
+  (D-precedence: lifetime absorbing). Manual remediation documented in
+  runbook §6; reconcile flags the divergence.
+- **Maestro suite statefulness** — login/forgot-password flows require a
+  signed-out sim and onboarding requires a plan-less account (documented
+  in their headers); sign-in/out utils under .maestro/utils/ drive those
+  states. Suite-runner orchestration (one command for the full matrix)
+  left as repo tooling for later.
+- Carried over from the native goal, unchanged: Google OAuth on native,
+  email-change OTP / data export (web links), Android pass, dark-mode
+  full-app sweep.
 
 ## Per-state paywall evidence (2026-06-12, DoD #9)
 

--- a/docs/billing-implementation-log.md
+++ b/docs/billing-implementation-log.md
@@ -27,6 +27,35 @@ Next and Metro bundlers.
 exactly what the ledger forbids); putting them in `packages/handicap-core`
 (wrong domain); putting them web-side only (native can't import).
 
+### D23 — Out-of-order cursor rides webhook_events (provider + event_time_ms) (2026-06-12)
+
+**What:** the per-provider out-of-order guard (DoD #3) needs the timestamp
+of the last APPLIED event per (user, provider). Two nullable columns were
+added to the existing `webhook_events` table — `provider`
+('stripe'|'apple') and `event_time_ms` — plus a partial index
+`(user_id, provider, event_time_ms) WHERE status='success'`. The guard
+reads `max(event_time_ms)` over success rows; the cursor advances on every
+successfully EVALUATED event (even ones that lose precedence and don't
+change the projection), because a newer evaluated fact from a provider
+makes every older fact from that provider obsolete regardless of who won.
+
+**Why:** the handoff mandates "idempotency via the existing webhook_events
+table" and an out-of-order guard, but provides no storage for the cursor.
+Extending the table the idempotency already lives in keeps one
+system-of-record for webhook processing state. Existing Stripe rows stay
+NULL — Stripe handler ordering semantics are explicitly unchanged
+(DoD #4 "updated minimally").
+
+**Alternatives rejected:** a dedicated cursor table (more schema surface
+for the same data); deriving order from the projection (impossible —
+CANCELLATION/UNCANCELLATION don't move period_end, so only event time
+orders them); profile-side last_event columns (claims/profile shape is
+frozen beyond billing_provider).
+
+**Backfill note:** existing paid profiles were backfilled
+`billing_provider='stripe'` (Stripe is the only provider that has ever
+billed this app); free/plan-less profiles stay NULL.
+
 ## Waivers
 
 (none yet)

--- a/docs/billing-implementation-log.md
+++ b/docs/billing-implementation-log.md
@@ -56,6 +56,33 @@ frozen beyond billing_provider).
 `billing_provider='stripe'` (Stripe is the only provider that has ever
 billed this app); free/plan-less profiles stay NULL.
 
+### D24 — PRODUCT_CHANGE writes nothing; cursor advances only on evaluated entitlement events (2026-06-12)
+
+**What:** the RC webhook acknowledges PRODUCT_CHANGE without touching the
+projection AND without advancing the ordering cursor. Likewise TRANSFER,
+TEST, unknown products, non-APP_STORE stores, and unhandled event types
+are recorded for idempotency with `event_time_ms = NULL` (no cursor
+advance). The cursor moves only on the seven evaluated entitlement events
+(INITIAL_PURCHASE, RENEWAL, CANCELLATION, UNCANCELLATION, BILLING_ISSUE,
+EXPIRATION, NON_RENEWING_PURCHASE).
+
+**Why:** RevenueCat's event-flows doc (read 2026-06-12) is explicit:
+upgrades dispatch PRODUCT_CHANGE *alongside a RENEWAL* that carries the
+new product; downgrades dispatch PRODUCT_CHANGE immediately while "the
+customer will retain their entitlement based on the original product"
+until a later RENEWAL applies it. Writing on PRODUCT_CHANGE would grant
+deferred downgrades early; advancing the cursor on it could mark the
+sibling RENEWAL stale and lose the actual product switch. The D-status-
+mapping table doesn't bind PRODUCT_CHANGE, so this is the faithful
+interpretation (verified by integration test: PRODUCT_CHANGE no-op, then
+RENEWAL with new product applies the downgrade).
+
+**Also decided here:** the double-contract and TRANSFER alerts are
+recorded queryably in the success row's `error_message`
+(`double_contract: kept <provider>` / `transfer: ...`) in addition to the
+Sentry alert — integration tests assert the recorded note, and operators
+can audit alerts without Sentry access.
+
 ## Waivers
 
 (none yet)

--- a/docs/billing-runbook.md
+++ b/docs/billing-runbook.md
@@ -1,0 +1,227 @@
+# Billing runbook — Apple in-app purchases via RevenueCat
+
+The console checklist for going live with cross-platform billing. The code
+side is DONE (see `docs/billing-implementation-log.md`): the backend
+projects Stripe and Apple events into one entitlement (`profile` table),
+the native app has a policy-aware paywall behind a provider seam, and the
+RevenueCat webhook is implemented and integration-tested. Everything below
+is console/account work only the project owner can do.
+
+**The architecture in two sentences** (full ledger:
+`docs/billing-implementation-handoff.md` §1): the DB `profile` row is the
+single source of truth for ENTITLEMENT; Stripe and Apple each own only the
+contracts they bill, and they never write to each other. RevenueCat is
+Apple-side plumbing only (purchasing, receipts, webhooks) — never the
+entitlement source of truth.
+
+The product lineup is fixed (D-products, in
+`packages/billing-core/src/constants.ts` — the one shared SKU module):
+
+| Plan | Apple product ID | Type | Price |
+|---|---|---|---|
+| Premium | `com.handicappin.premium.yearly` | Auto-renewable, 1 year | $19/yr |
+| Unlimited | `com.handicappin.unlimited.yearly` | Auto-renewable, 1 year | $29/yr |
+| Lifetime | `com.handicappin.lifetime` | Non-consumable | $149 |
+
+No monthly products. Both subscriptions live in ONE subscription group so
+Apple handles upgrade/downgrade natively.
+
+---
+
+## 1. App Store Connect
+
+Prereq: the app record exists with bundle id `com.handicappin.app`
+(Apps → + → New App if not).
+
+### 1a. Agreements & banking (blocker for everything else)
+
+1. **Business → Agreements**: accept the **Paid Applications** agreement.
+2. Complete **banking** and **tax** forms (payouts won't flow and IAPs
+   won't be testable in TestFlight without them).
+3. **Small Business Program** (15% commission instead of 30% under $1M/yr):
+   enroll at <https://developer.apple.com/app-store/small-business-program/>
+   — do this BEFORE launch; it is not retroactive for past sales.
+
+### 1b. Subscription group + the two auto-renewables
+
+1. App page → **Monetization → Subscriptions** → **Create** a subscription
+   group. Reference name: `handicappin_plans` (must match
+   `APPLE_SUBSCRIPTION_GROUP` in `packages/billing-core` for documentation
+   purposes; Apple never sees the code constant).
+2. In the group, create subscription #1:
+   - Reference name: `Premium Yearly`
+   - **Product ID: `com.handicappin.premium.yearly`** (EXACT — the webhook
+     maps product id → plan; a typo here means purchases grant nothing).
+   - Duration: **1 year**. Price: **$19 USD** tier.
+   - Localization (en-US): display name "Premium", description e.g. "For
+     golf enthusiasts — unlimited round logging."
+3. Create subscription #2 in the SAME group:
+   - Reference name: `Unlimited Yearly`
+   - **Product ID: `com.handicappin.unlimited.yearly`**
+   - Duration: **1 year**. Price: **$29 USD** tier.
+   - Localization: "Unlimited" / "Unlimited rounds, statistics, and
+     calculators."
+4. **Group ranking**: put Unlimited ABOVE Premium (rank 1 = Unlimited,
+   rank 2 = Premium) — this is how Apple decides upgrade (immediate,
+   prorated) vs downgrade (at next renewal). The app's "Switch to
+   Unlimited/Premium" buttons rely on it.
+5. Each subscription needs a **review screenshot** (any paywall screenshot
+   at submission time) and the group needs at least one localization.
+
+### 1c. The non-consumable
+
+1. **Monetization → In-App Purchases** → **Create**:
+   - Type: **Non-Consumable**
+   - Reference name: `Lifetime`
+   - **Product ID: `com.handicappin.lifetime`**
+   - Price: **$149 USD** tier.
+   - Localization: "Lifetime" / "Unlimited access, forever."
+
+### 1d. Sandbox tester
+
+**Users and Access → Sandbox → Testers** → create a sandbox Apple
+account (use a +alias email you control). You'll sign into it on the
+TestFlight device under Settings → App Store → Sandbox Account.
+
+---
+
+## 2. RevenueCat console (app.revenuecat.com)
+
+1. **Create a project** (e.g. "Handicappin").
+2. **Add the iOS app**: Project settings → Apps → + New → App Store.
+   Bundle ID `com.handicappin.app`.
+3. **App Store Connect credentials** (so RC can validate receipts and read
+   products): follow RC's prompts to upload an **In-App Purchase Key**
+   (App Store Connect → Users and Access → Integrations → In-App Purchase)
+   and the **App-Specific Shared Secret** (legacy receipt validation).
+4. **Products**: Project → Product catalog → + New → import / add the three
+   product ids EXACTLY as in §1b/§1c.
+5. **Entitlements** — create three, names EXACTLY (`RC_ENTITLEMENT_IDS` in
+   `packages/billing-core`):
+   - `premium`  ← attach `com.handicappin.premium.yearly`
+   - `unlimited` ← attach `com.handicappin.unlimited.yearly`
+   - `lifetime` ← attach `com.handicappin.lifetime`
+6. **Offering**: create the `default` offering with three packages:
+   - package `premium_yearly` (custom) → premium yearly product
+   - package `unlimited_yearly` (custom) → unlimited yearly product
+   - `$rc_lifetime` (standard Lifetime package) → lifetime product
+   The native paywall reads `offerings.current` — make this offering
+   **current**.
+7. **API keys** (Project settings → API keys):
+   - **Public Apple SDK key** (`appl_...`) → the native app
+     (`EXPO_PUBLIC_REVENUECAT_IOS_API_KEY`).
+   - **Secret key** (`sk_...`) → the web backend (`REVENUECAT_API_KEY`,
+     used only by `scripts/reconcile-billing.mjs`).
+8. **Webhook** (Project settings → Integrations → Webhooks → + New):
+   - URL: `https://handicappin.com/api/webhooks/revenuecat`
+   - **Authorization header value**: generate a long random secret, e.g.
+     `Bearer <openssl rand -hex 32>` — RevenueCat sends the value VERBATIM
+     in the `Authorization` header; the route compares the whole string
+     timing-safe. Whatever exact string you paste here must equal
+     `REVENUECAT_WEBHOOK_AUTH_TOKEN` on the server.
+   - Environment: send **both** sandbox + production (the route logs the
+     environment; sandbox events against prod data are filtered by app
+     user id anyway).
+   - Event types: leave "all" (unhandled types are acknowledged and
+     ignored by design).
+
+**Do NOT** enable RevenueCat's Stripe integration or Web Billing
+(D-rc-scope: RC is Apple-side plumbing only — the existing Stripe webhook
+keeps owning Stripe).
+
+---
+
+## 3. Environment variables
+
+### Web (Vercel project / `apps/web/.env.local` for local testing)
+
+| Var | Value | Notes |
+|---|---|---|
+| `REVENUECAT_WEBHOOK_AUTH_TOKEN` | the exact Authorization value from §2.8 | Webhook 401s without it in prod (fails closed; optional in dev). |
+| `REVENUECAT_API_KEY` | RC **secret** key (`sk_...`) | Only the reconcile script reads it; without it apple-side reconciliation is skipped gracefully. |
+
+Both are declared in `apps/web/env.ts` (optional, so missing values never
+break dev/CI).
+
+### Native (`apps/native/eas.json` — placeholders already in place)
+
+| Profile | Var | Value |
+|---|---|---|
+| `preview`, `production` | `EXPO_PUBLIC_REVENUECAT_IOS_API_KEY` | RC **public** Apple SDK key (`appl_...`) — replaces `appl_SET-ME`. |
+| `development` | (leave UNSET) | Key-less builds run the mock provider — that's the D-seam switch, also used by CI and the sim test suite. |
+
+Also still pending from the native goal: real `EXPO_PUBLIC_SUPABASE_URL`,
+`EXPO_PUBLIC_SUPABASE_ANON_KEY` in preview/production.
+
+---
+
+## 4. TestFlight / sandbox test plan
+
+Build: `eas build --profile preview --platform ios` (the preview profile
+now carries the RC key → the app uses the REAL SDK; StoreKit capability is
+added automatically by EAS for IAP-enabled apps). Submit to TestFlight
+(`eas submit`), install, sign the DEVICE into the sandbox tester account
+(Settings → App Store → Sandbox Account), then walk this matrix with a
+fresh app account (sign up in-app):
+
+1. **Purchase premium** (onboarding paywall → Premium → Apple sheet):
+   - App: plan flips to premium after the webhook lands (pull to refresh /
+     reopen). Check `profile`: `plan_selected=premium`,
+     `subscription_status=active`, `billing_provider=apple`,
+     `current_period_end` ≈ +1h (sandbox year = 1 hour).
+   - RC dashboard: customer (id = the Supabase user id) shows the
+     `premium` entitlement; webhook log shows `INITIAL_PURCHASE` → 200.
+2. **Upgrade to unlimited** (Profile → Billing → "Switch to Unlimited"):
+   immediate (Apple upgrade), webhook `RENEWAL`/`PRODUCT_CHANGE` pair,
+   projection flips to unlimited.
+3. **Downgrade to premium**: takes effect at the (1-hour sandbox) renewal
+   — projection stays unlimited until the deferred `RENEWAL` lands.
+4. **Cancel** (sandbox: Settings → App Store → Sandbox Account → Manage):
+   webhook `CANCELLATION` → `cancel_at_period_end=true`, access continues;
+   paywall shows "Cancels on ...".
+5. **Let it expire** (sandbox renews a few times then expires ~6 renewals,
+   or cancel + wait an hour): webhook `EXPIRATION` → plan `free`,
+   `billing_provider` NULL, paywall purchasable again.
+6. **Lifetime**: buy on a fresh account → `NON_RENEWING_PURCHASE` →
+   `plan_selected=lifetime`; paywall shows no purchase buttons.
+7. **Restore Purchases** on a reinstall/second device with the same
+   sandbox Apple account: entitlement comes back without a charge.
+8. **Stripe sanity**: an existing web-subscribed (stripe) account in the
+   app shows the neutral "managed on handicappin.com" copy and NO purchase
+   buttons.
+9. **Reconcile**: `node scripts/reconcile-billing.mjs` (dry run) — apple
+   users now diff against RC; expect "in sync".
+
+Webhook logs: Vercel function logs for
+`/api/webhooks/revenuecat`; every event also lands in the `webhook_events`
+table (`event_type LIKE 'revenuecat.%'`).
+
+## 5. Go-live order
+
+1. §1 App Store Connect (agreements FIRST — products can't be tested
+   without banking/tax done).
+2. §2 RevenueCat project + products + entitlements + offering + keys +
+   webhook (point it at production from day one).
+3. §3 env vars: Vercel (`REVENUECAT_WEBHOOK_AUTH_TOKEN`,
+   `REVENUECAT_API_KEY`) → redeploy web BEFORE any purchase can happen.
+4. §4 TestFlight pass (sandbox) — the full matrix above.
+5. Submit the app for review WITH the in-app purchases attached to the
+   version (App Review reviews them together; the paywall's auto-renew
+   disclosure + Terms/Privacy links and the in-app delete-account entry
+   are already in place — 3.1.2 / 5.1.1(v)).
+6. After approval: spot-check one real purchase + refund it, run the
+   reconcile dry-run, enroll in the Small Business Program if not done.
+
+## 6. Known edges (by design — see the implementation log)
+
+- **Apple lifetime refunds do NOT auto-revoke**: D-precedence makes
+  lifetime absorbing; RC sends CANCELLATION/EXPIRATION on refund of the
+  non-consumable but the projection keeps lifetime. If you refund a
+  lifetime purchase, revoke manually (set the profile to free) — the
+  reconcile dry-run will flag the mismatch.
+- **Double contracts alert, never auto-cancel**: if a user ends up actively
+  paying BOTH Stripe and Apple, the webhook keeps max entitlement, raises
+  a Sentry alert (`billing.double_contract`) and records it on the
+  `webhook_events` row — refund/cancel one side manually.
+- **Free-tier selection and the EARLY100 lifetime promo stay web flows**;
+  the native paywall says so on those CTAs.

--- a/packages/billing-core/package.json
+++ b/packages/billing-core/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@handicappin/billing-core",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "files": [
+    "src"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/billing-core/src/constants.ts
+++ b/packages/billing-core/src/constants.ts
@@ -1,0 +1,81 @@
+/**
+ * THE shared SKU↔plan mapping (decision ledger D-products). Used by the
+ * RevenueCat webhook (apps/web), the native paywall (apps/native), the
+ * reconcile script, and the owner runbook — change product lineup HERE only.
+ *
+ * Lineup is yearly-only plus a one-time lifetime unlock:
+ *   - com.handicappin.premium.yearly    auto-renewable (ONE subscription group)
+ *   - com.handicappin.unlimited.yearly  auto-renewable (same group)
+ *   - com.handicappin.lifetime          non-consumable
+ */
+
+/** Plans as the backend projection knows them (mirrors web's PLAN_TYPES). */
+export const PLAN_TYPES = ["free", "premium", "unlimited", "lifetime"] as const;
+export type PlanType = (typeof PLAN_TYPES)[number];
+
+/** Plans a user can actually pay for. */
+export type PaidPlan = Exclude<PlanType, "free">;
+
+/** Billing providers that can own a contract (profile.billing_provider). */
+export const BILLING_PROVIDERS = ["stripe", "apple"] as const;
+export type BillingProviderId = (typeof BILLING_PROVIDERS)[number];
+
+/** Apple App Store product identifiers (D-products — LOCKED). */
+export const APPLE_SKUS = {
+  premiumYearly: "com.handicappin.premium.yearly",
+  unlimitedYearly: "com.handicappin.unlimited.yearly",
+  lifetime: "com.handicappin.lifetime",
+} as const;
+
+export type AppleSku = (typeof APPLE_SKUS)[keyof typeof APPLE_SKUS];
+
+/** The single App Store subscription group both auto-renewables live in. */
+export const APPLE_SUBSCRIPTION_GROUP = "handicappin_plans";
+
+/**
+ * RevenueCat entitlement identifiers, named after the plan they grant.
+ * The runbook maps each product to exactly one of these in the RC console;
+ * native surfaces key their entitlement checks off the same names.
+ */
+export const RC_ENTITLEMENT_IDS = {
+  premium: "premium",
+  unlimited: "unlimited",
+  lifetime: "lifetime",
+} as const;
+
+export const APPLE_SKU_TO_PLAN: Record<AppleSku, PaidPlan> = {
+  [APPLE_SKUS.premiumYearly]: "premium",
+  [APPLE_SKUS.unlimitedYearly]: "unlimited",
+  [APPLE_SKUS.lifetime]: "lifetime",
+};
+
+/** Map an App Store product id to its plan; null for unknown products. */
+export function appleSkuToPlan(productId: string): PaidPlan | null {
+  return (APPLE_SKU_TO_PLAN as Record<string, PaidPlan>)[productId] ?? null;
+}
+
+export function planToAppleSku(plan: PaidPlan): AppleSku {
+  switch (plan) {
+    case "premium":
+      return APPLE_SKUS.premiumYearly;
+    case "unlimited":
+      return APPLE_SKUS.unlimitedYearly;
+    case "lifetime":
+      return APPLE_SKUS.lifetime;
+  }
+}
+
+/**
+ * Entitlement precedence (D-precedence): lifetime > unlimited > premium > free.
+ * Matches web's plan hierarchy in apps/web/lib/stripe.ts.
+ */
+export const PLAN_TIER_RANK: Record<PlanType, number> = {
+  free: 0,
+  premium: 1,
+  unlimited: 2,
+  lifetime: 3,
+};
+
+export function planRank(plan: PlanType | null): number {
+  return plan ? PLAN_TIER_RANK[plan] : 0;
+}

--- a/packages/billing-core/src/index.ts
+++ b/packages/billing-core/src/index.ts
@@ -1,0 +1,18 @@
+export {
+  PLAN_TYPES,
+  BILLING_PROVIDERS,
+  APPLE_SKUS,
+  APPLE_SUBSCRIPTION_GROUP,
+  RC_ENTITLEMENT_IDS,
+  APPLE_SKU_TO_PLAN,
+  PLAN_TIER_RANK,
+  appleSkuToPlan,
+  planToAppleSku,
+  planRank,
+} from "./constants";
+export type {
+  PlanType,
+  PaidPlan,
+  BillingProviderId,
+  AppleSku,
+} from "./constants";

--- a/packages/billing-core/tsconfig.json
+++ b/packages/billing-core/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "lib": ["es2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,9 @@ importers:
       '@expo/ui':
         specifier: ~56.0.16
         version: 56.0.16(@babel/core@7.29.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(expo@56.0.9)(react-dom@19.2.3(react@19.2.3))(react-native-reanimated@4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      '@handicappin/billing-core':
+        specifier: workspace:*
+        version: link:../../packages/billing-core
       '@handicappin/handicap-core':
         specifier: workspace:*
         version: link:../../packages/handicap-core
@@ -194,6 +197,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@handicappin/billing-core':
+        specifier: workspace:*
+        version: link:../../packages/billing-core
       '@handicappin/handicap-core':
         specifier: workspace:*
         version: link:../../packages/handicap-core
@@ -441,6 +447,12 @@ importers:
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+
+  packages/billing-core:
+    devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
   packages/handicap-core:
     devDependencies:
@@ -12938,7 +12950,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
       react-native-gesture-handler:
         specifier: ~2.31.1
         version: 2.31.2(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
+      react-native-purchases:
+        specifier: ^10.3.0
+        version: 10.3.0(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
       react-native-reanimated:
         specifier: 4.3.1
         version: 4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3)
@@ -3583,6 +3586,15 @@ packages:
   '@resvg/resvg-wasm@2.4.0':
     resolution: {integrity: sha512-C7c51Nn4yTxXFKvgh2txJFNweaVcfUPQxwEUFw4aWsCmfiBDJsTSwviIF8EcwjQ6k8bPyMWCl1vw4BdxE569Cg==}
     engines: {node: '>= 10'}
+
+  '@revenuecat/purchases-js-hybrid-mappings@18.14.1':
+    resolution: {integrity: sha512-O5U3h7qsvGFCUG1C4Kmb/CgGwK/zSF5NDXVu2v1AMTlKxXdDU3hpDyC/lesfmSpW8x4qIPeQU+p9wLMY8V68Bg==}
+
+  '@revenuecat/purchases-js@1.42.3':
+    resolution: {integrity: sha512-CkR+Jj0QtsO+SO1AN7stXwJsWGNO33NJEPXkvk//v1ppB0Qff1B3y+022rCo27tJiQHFllR0K78czcUKBrizvg==}
+
+  '@revenuecat/purchases-typescript-internal@18.14.1':
+    resolution: {integrity: sha512-A4dn2jxmSVWO7LbjGxHT/tNFH3INKCoM0utu9fPzTtqdi8hd61mPrjBAzBLMCHal4KzCzp8MKRguNCedzLP7qA==}
 
   '@rollup/plugin-commonjs@28.0.1':
     resolution: {integrity: sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA==}
@@ -8307,6 +8319,16 @@ packages:
       react: '*'
       react-native: '*'
 
+  react-native-purchases@10.3.0:
+    resolution: {integrity: sha512-PTxp+MbGIIeZomcTcUGiZLw6IzoSd4Vmfpw0Htdxk5axPBS4O+sRXtgScI6rsEe1EwKSqBHSdi4LPQhZgZeAgQ==}
+    peerDependencies:
+      react: '>= 16.6.3'
+      react-native: '>= 0.73.0'
+      react-native-web: '*'
+    peerDependenciesMeta:
+      react-native-web:
+        optional: true
+
   react-native-reanimated@4.3.1:
     resolution: {integrity: sha512-KhGsS0YkCA+gusgyzlf9hnqzVPIR398KTpqXyqq/+yYJJPAvyEEPKcxlB0xtOOXSMrR2A9uRKVARVQhZwrOh+Q==}
     peerDependencies:
@@ -12950,9 +12972,7 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-colors@0.74.89': {}
 
@@ -12985,6 +13005,14 @@ snapshots:
       react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1)
 
   '@resvg/resvg-wasm@2.4.0': {}
+
+  '@revenuecat/purchases-js-hybrid-mappings@18.14.1':
+    dependencies:
+      '@revenuecat/purchases-js': 1.42.3
+
+  '@revenuecat/purchases-js@1.42.3': {}
+
+  '@revenuecat/purchases-typescript-internal@18.14.1': {}
 
   '@rollup/plugin-commonjs@28.0.1(rollup@4.57.1)':
     dependencies:
@@ -15821,7 +15849,7 @@ snapshots:
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.2(jiti@2.6.1))
@@ -15854,7 +15882,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -15904,7 +15932,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -18425,6 +18453,15 @@ snapshots:
     dependencies:
       react: 19.2.3
       react-native: 0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
+
+  react-native-purchases@10.3.0(react-native-web@0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@revenuecat/purchases-js-hybrid-mappings': 18.14.1
+      '@revenuecat/purchases-typescript-internal': 18.14.1
+      react: 19.2.3
+      react-native: 0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3)
+    optionalDependencies:
+      react-native-web: 0.21.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
   react-native-reanimated@4.3.1(react-native-worklets@0.8.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3))(react-native@0.85.3(@babel/core@7.29.0)(@react-native/metro-config@0.85.3(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.3))(react@19.2.3):
     dependencies:

--- a/scripts/lib/reconcile-billing-core.mjs
+++ b/scripts/lib/reconcile-billing-core.mjs
@@ -1,0 +1,185 @@
+/**
+ * Pure reconcile logic for scripts/reconcile-billing.mjs (handoff DoD #6).
+ * No I/O here — fetching lives in the CLI; this module normalizes provider
+ * payloads into the projection shape and diffs them, so the logic is
+ * unit-testable from the web vitest suite.
+ *
+ * "Projection" = the profile row's billing slice:
+ *   { plan, status, currentPeriodEnd (unix s), cancelAtPeriodEnd, provider }
+ */
+
+export const APPLE_SKU_TO_PLAN = {
+  "com.handicappin.premium.yearly": "premium",
+  "com.handicappin.unlimited.yearly": "unlimited",
+  "com.handicappin.lifetime": "lifetime",
+};
+
+/**
+ * Normalize a Stripe subscription list (GET /v1/subscriptions?customer=...,
+ * status=all) into the provider-truth billing state for the contract Stripe
+ * bills. Picks the newest relevant subscription: actives first, then
+ * past_due/trialing, then anything else.
+ *
+ * @param subscriptions Stripe subscription objects
+ * @param priceToPlan map of stripe price id -> plan
+ * @returns provider state or null when Stripe shows no subscription at all
+ */
+export function normalizeStripeSubscriptions(subscriptions, priceToPlan) {
+  if (!Array.isArray(subscriptions) || subscriptions.length === 0) return null;
+
+  const rank = (sub) => {
+    if (sub.status === "active" || sub.status === "trialing") return 2;
+    if (sub.status === "past_due" || sub.status === "unpaid") return 1;
+    return 0;
+  };
+  const sorted = [...subscriptions].sort(
+    (a, b) => rank(b) - rank(a) || (b.created ?? 0) - (a.created ?? 0),
+  );
+  const sub = sorted[0];
+  const item = sub.items?.data?.[0];
+  const plan = item?.price?.id ? (priceToPlan[item.price.id] ?? null) : null;
+
+  // Stripe ended subscriptions project as the free tier (mirror of
+  // customer.subscription.deleted).
+  if (sub.status === "canceled" || sub.status === "incomplete_expired") {
+    return {
+      plan: "free",
+      status: "canceled",
+      currentPeriodEnd: null,
+      cancelAtPeriodEnd: false,
+    };
+  }
+
+  return {
+    plan,
+    status: sub.status ?? null,
+    currentPeriodEnd: item?.current_period_end ?? null,
+    cancelAtPeriodEnd: Boolean(sub.cancel_at_period_end || sub.cancel_at),
+  };
+}
+
+/**
+ * Normalize a RevenueCat GET /v1/subscribers/{id} response into provider
+ * truth for the apple-billed contract.
+ *
+ * RC subscriber shape (official REST docs): subscriber.subscriptions is a
+ * map of product_id -> { expires_date, unsubscribe_detected_at,
+ * billing_issues_detected_at, period_type, store }, and
+ * subscriber.non_subscriptions maps product_id -> purchase list.
+ */
+export function normalizeRevenueCatSubscriber(subscriber, nowMs) {
+  if (!subscriber || typeof subscriber !== "object") return null;
+
+  // Lifetime: any recorded purchase of the lifetime SKU wins.
+  const nonSubs = subscriber.non_subscriptions ?? {};
+  for (const [productId, purchases] of Object.entries(nonSubs)) {
+    if (
+      APPLE_SKU_TO_PLAN[productId] === "lifetime" &&
+      Array.isArray(purchases) &&
+      purchases.length > 0
+    ) {
+      return {
+        plan: "lifetime",
+        status: "active",
+        currentPeriodEnd: null,
+        cancelAtPeriodEnd: false,
+      };
+    }
+  }
+
+  const subs = subscriber.subscriptions ?? {};
+  let best = null;
+  for (const [productId, sub] of Object.entries(subs)) {
+    const plan = APPLE_SKU_TO_PLAN[productId];
+    if (!plan || sub?.store !== "app_store") continue;
+    const expiresMs = sub.expires_date ? Date.parse(sub.expires_date) : null;
+    const isLive =
+      expiresMs !== null && expiresMs > nowMs && !sub.refunded_at;
+    const candidate = {
+      plan,
+      expiresMs,
+      isLive,
+      hasBillingIssue: Boolean(sub.billing_issues_detected_at),
+      unsubscribed: Boolean(sub.unsubscribe_detected_at),
+      periodType: sub.period_type ?? "normal",
+    };
+    if (
+      !best ||
+      Number(candidate.isLive) - Number(best.isLive) > 0 ||
+      (candidate.isLive === best.isLive &&
+        (candidate.expiresMs ?? 0) > (best.expiresMs ?? 0))
+    ) {
+      best = candidate;
+    }
+  }
+
+  if (!best) return null;
+
+  if (!best.isLive) {
+    return {
+      plan: "free",
+      status: "canceled",
+      currentPeriodEnd: null,
+      cancelAtPeriodEnd: false,
+    };
+  }
+
+  return {
+    plan: best.plan,
+    status: best.hasBillingIssue
+      ? "past_due"
+      : best.periodType === "trial"
+        ? "trialing"
+        : "active",
+    currentPeriodEnd: best.expiresMs !== null ? Math.floor(best.expiresMs / 1000) : null,
+    cancelAtPeriodEnd: best.unsubscribed,
+  };
+}
+
+/**
+ * Field-level diff between the stored projection and provider truth.
+ * `providerState === null` means the provider has no record — reported as a
+ * single "presence" diff (ambiguous: could be env mismatch; never auto-fixed).
+ */
+export function diffBillingState(projection, providerState) {
+  if (providerState === null) {
+    return [
+      {
+        field: "presence",
+        projection: `${projection.plan}/${projection.status}`,
+        provider: "no record",
+      },
+    ];
+  }
+  const diffs = [];
+  const fields = ["plan", "status", "currentPeriodEnd", "cancelAtPeriodEnd"];
+  for (const field of fields) {
+    const a = projection[field] ?? null;
+    const b = providerState[field] ?? null;
+    if (a !== b) {
+      diffs.push({ field, projection: a, provider: b });
+    }
+  }
+  return diffs;
+}
+
+/**
+ * Whether --apply may write this correction. Conservative by design:
+ *  - never touches lifetime projections (D-precedence: absorbing);
+ *  - never acts on "no record" presence diffs (ambiguous);
+ *  - only corrects the projection from the provider that OWNS the contract
+ *    (projection.provider must match the side being reconciled).
+ */
+export function decideApply(projection, providerState, diffs, side) {
+  if (diffs.length === 0) return { apply: false, reason: "in-sync" };
+  if (projection.plan === "lifetime") {
+    return { apply: false, reason: "lifetime-locked (manual only)" };
+  }
+  if (providerState === null) {
+    return { apply: false, reason: "provider has no record (ambiguous)" };
+  }
+  if (projection.provider !== side) {
+    return { apply: false, reason: "projection owned by other provider" };
+  }
+  return { apply: true, reason: "provider is source of truth for its contract" };
+}

--- a/scripts/reconcile-billing.mjs
+++ b/scripts/reconcile-billing.mjs
@@ -1,0 +1,299 @@
+/**
+ * Billing reconciliation (handoff DoD #6): diff the DB entitlement
+ * projection against each provider's contract truth.
+ *
+ *   - stripe-provider users → Stripe REST API (TEST key)
+ *   - apple-provider users  → RevenueCat REST API (skips gracefully when
+ *     REVENUECAT_API_KEY is absent)
+ *
+ * DRY-RUN BY DEFAULT: prints diffs and exits 0. `--apply` writes
+ * conservative same-provider corrections only (never lifetime, never
+ * "provider has no record" cases) — see scripts/lib/reconcile-billing-core.mjs.
+ *
+ * Usage:
+ *   node scripts/reconcile-billing.mjs [--apply] [--user <uuid>]
+ *
+ * Reads env from apps/web/.env.local + apps/web/.env (first hit wins):
+ * DATABASE_URL is NOT used — profiles are read via the Supabase REST API
+ * with the service-role key, matching the repo's dependency-free script
+ * pattern (see scripts/seed-native-test-rounds.mjs).
+ */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  normalizeStripeSubscriptions,
+  normalizeRevenueCatSubscriber,
+  diffBillingState,
+  decideApply,
+} from "./lib/reconcile-billing-core.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function loadEnv() {
+  const env = { ...process.env };
+  for (const file of ["apps/web/.env.local", "apps/web/.env"]) {
+    try {
+      const content = readFileSync(join(ROOT, file), "utf8");
+      for (const line of content.split("\n")) {
+        const match = line.match(/^([A-Z0-9_]+)=(.*)$/);
+        if (match && env[match[1]] === undefined) {
+          env[match[1]] = match[2].replace(/^["']|["']$/g, "");
+        }
+      }
+    } catch {
+      // file absent — fine
+    }
+  }
+  return env;
+}
+
+const env = loadEnv();
+const args = process.argv.slice(2);
+const APPLY = args.includes("--apply");
+const userFilter = args.includes("--user")
+  ? args[args.indexOf("--user") + 1]
+  : null;
+
+const SUPABASE_URL = env.NEXT_PUBLIC_SUPABASE_URL;
+const SERVICE_ROLE_KEY = env.SUPABASE_SERVICE_ROLE_KEY;
+const STRIPE_KEY = env.STRIPE_SECRET_KEY;
+const RC_KEY = env.REVENUECAT_API_KEY;
+
+if (!SUPABASE_URL || !SERVICE_ROLE_KEY) {
+  console.error(
+    "Missing NEXT_PUBLIC_SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY (apps/web/.env*)",
+  );
+  process.exit(1);
+}
+if (STRIPE_KEY && !STRIPE_KEY.startsWith("sk_test_")) {
+  console.error(
+    "Refusing to run: STRIPE_SECRET_KEY is not a TEST key (sk_test_...). " +
+      "This script is test-mode only.",
+  );
+  process.exit(1);
+}
+
+async function supabaseRest(path, init = {}) {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
+    ...init,
+    headers: {
+      apikey: SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+      "Content-Type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`Supabase REST ${path}: ${res.status} ${await res.text()}`);
+  }
+  return res.status === 204 ? null : res.json();
+}
+
+async function stripeRest(path) {
+  const res = await fetch(`https://api.stripe.com/v1/${path}`, {
+    headers: { Authorization: `Bearer ${STRIPE_KEY}` },
+  });
+  if (!res.ok) {
+    throw new Error(`Stripe REST ${path}: ${res.status} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function revenueCatSubscriber(appUserId) {
+  const res = await fetch(
+    `https://api.revenuecat.com/v1/subscribers/${encodeURIComponent(appUserId)}`,
+    { headers: { Authorization: `Bearer ${RC_KEY}` } },
+  );
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new Error(`RevenueCat REST: ${res.status} ${await res.text()}`);
+  }
+  const body = await res.json();
+  return body.subscriber ?? null;
+}
+
+function projectionOf(row) {
+  return {
+    plan: row.plan_selected,
+    status: row.subscription_status,
+    currentPeriodEnd: row.current_period_end,
+    cancelAtPeriodEnd: row.cancel_at_period_end,
+    provider: row.billing_provider,
+  };
+}
+
+function fmtState(state) {
+  if (state === null) return "(no record)";
+  return `${state.plan}/${state.status} periodEnd=${state.currentPeriodEnd ?? "-"} cap=${state.cancelAtPeriodEnd}`;
+}
+
+async function applyCorrection(userId, providerState) {
+  // PostgREST can't increment in place — read the version, write everything
+  // in one PATCH (bumped version refreshes clients' claims).
+  const rows = await supabaseRest(
+    `profile?id=eq.${userId}&select=billing_version`,
+  );
+  await supabaseRest(`profile?id=eq.${userId}`, {
+    method: "PATCH",
+    headers: { Prefer: "return=minimal" },
+    body: JSON.stringify({
+      plan_selected: providerState.plan,
+      subscription_status: providerState.status,
+      current_period_end: providerState.currentPeriodEnd,
+      cancel_at_period_end: providerState.cancelAtPeriodEnd,
+      billing_version: rows[0].billing_version + 1,
+    }),
+  });
+}
+
+const PRICE_TO_PLAN = {};
+if (env.STRIPE_PREMIUM_PRICE_ID) PRICE_TO_PLAN[env.STRIPE_PREMIUM_PRICE_ID] = "premium";
+if (env.STRIPE_UNLIMITED_PRICE_ID) PRICE_TO_PLAN[env.STRIPE_UNLIMITED_PRICE_ID] = "unlimited";
+if (env.STRIPE_UNLIMITED_LIFETIME_PRICE_ID) PRICE_TO_PLAN[env.STRIPE_UNLIMITED_LIFETIME_PRICE_ID] = "lifetime";
+
+async function reconcileStripeUser(row) {
+  const projection = projectionOf(row);
+
+  if (projection.plan === "lifetime") {
+    // One-time payment: no subscription to diff. Verified via the refund
+    // webhook path; reported informationally.
+    return { userId: row.id, side: "stripe", info: "lifetime (one-time) — no subscription to diff", diffs: [] };
+  }
+
+  const customers = await supabaseRest(
+    `stripe_customers?user_id=eq.${row.id}&select=stripe_customer_id`,
+  );
+  if (!customers.length) {
+    return {
+      userId: row.id,
+      side: "stripe",
+      diffs: diffBillingState(projection, null),
+      providerState: null,
+      projection,
+      note: "no stripe_customers row (SQL-bootstrapped local user or env mismatch)",
+    };
+  }
+
+  const subs = await stripeRest(
+    `subscriptions?customer=${customers[0].stripe_customer_id}&status=all&limit=10`,
+  );
+  const providerState = normalizeStripeSubscriptions(subs.data, PRICE_TO_PLAN);
+  const diffs = diffBillingState(projection, providerState);
+  return { userId: row.id, side: "stripe", diffs, providerState, projection };
+}
+
+async function reconcileAppleUser(row) {
+  const projection = projectionOf(row);
+  const subscriber = await revenueCatSubscriber(row.id);
+  const providerState = subscriber
+    ? normalizeRevenueCatSubscriber(subscriber, Date.now())
+    : null;
+  const diffs = diffBillingState(projection, providerState);
+  return { userId: row.id, side: "apple", diffs, providerState, projection };
+}
+
+async function main() {
+  console.log(
+    `reconcile-billing ${APPLY ? "--apply (conservative)" : "(dry run)"} — ${new Date().toISOString()}`,
+  );
+
+  let query =
+    "profile?select=id,email,plan_selected,subscription_status,current_period_end,cancel_at_period_end,billing_provider,billing_version&billing_provider=not.is.null&order=email";
+  if (userFilter) {
+    query += `&id=eq.${userFilter}`;
+  }
+  const rows = await supabaseRest(query);
+
+  const stripeRows = rows.filter((r) => r.billing_provider === "stripe");
+  const appleRows = rows.filter((r) => r.billing_provider === "apple");
+  console.log(
+    `${rows.length} attributed profiles (${stripeRows.length} stripe, ${appleRows.length} apple)\n`,
+  );
+
+  const results = [];
+
+  if (stripeRows.length > 0) {
+    if (!STRIPE_KEY) {
+      console.log(`! STRIPE_SECRET_KEY absent — skipping ${stripeRows.length} stripe-provider users\n`);
+    } else {
+      for (const row of stripeRows) {
+        try {
+          results.push({ email: row.email, ...(await reconcileStripeUser(row)) });
+        } catch (error) {
+          results.push({ email: row.email, userId: row.id, side: "stripe", error: String(error.message ?? error), diffs: [] });
+        }
+      }
+    }
+  }
+
+  if (appleRows.length > 0) {
+    if (!RC_KEY) {
+      console.log(
+        `! REVENUECAT_API_KEY absent — skipping ${appleRows.length} apple-provider user(s). ` +
+          `Set it (RC dashboard → API keys, secret) to reconcile Apple-side contracts.\n`,
+      );
+    } else {
+      for (const row of appleRows) {
+        try {
+          results.push({ email: row.email, ...(await reconcileAppleUser(row)) });
+        } catch (error) {
+          results.push({ email: row.email, userId: row.id, side: "apple", error: String(error.message ?? error), diffs: [] });
+        }
+      }
+    }
+  }
+
+  let inSync = 0;
+  let diffCount = 0;
+  let applied = 0;
+  let errors = 0;
+
+  for (const r of results) {
+    if (r.error) {
+      errors += 1;
+      console.log(`✗ ${r.email} [${r.side}] ERROR: ${r.error}`);
+      continue;
+    }
+    if (r.info) {
+      console.log(`• ${r.email} [${r.side}] ${r.info}`);
+      inSync += 1;
+      continue;
+    }
+    if (r.diffs.length === 0) {
+      inSync += 1;
+      console.log(`✓ ${r.email} [${r.side}] in sync (${fmtState(r.projection)})`);
+      continue;
+    }
+
+    diffCount += 1;
+    console.log(`≠ ${r.email} [${r.side}] DIFF${r.note ? ` (${r.note})` : ""}`);
+    console.log(`    projection: ${fmtState(r.projection)}`);
+    console.log(`    provider:   ${fmtState(r.providerState ?? null)}`);
+    for (const d of r.diffs) {
+      console.log(`    - ${d.field}: db=${d.projection} provider=${d.provider}`);
+    }
+
+    const verdict = decideApply(r.projection, r.providerState ?? null, r.diffs, r.side);
+    if (APPLY && verdict.apply) {
+      await applyCorrection(r.userId, r.providerState);
+      applied += 1;
+      console.log(`    → APPLIED provider state`);
+    } else if (verdict.apply) {
+      console.log(`    → would apply with --apply (${verdict.reason})`);
+    } else {
+      console.log(`    → not auto-correctable: ${verdict.reason}`);
+    }
+  }
+
+  console.log(
+    `\nSummary: ${inSync} in sync, ${diffCount} diff(s), ${applied} applied, ${errors} error(s)` +
+      (!RC_KEY && appleRows.length > 0 ? `, ${appleRows.length} apple skipped (no key)` : ""),
+  );
+  process.exit(errors > 0 ? 1 : 0);
+}
+
+main().catch((error) => {
+  console.error("reconcile-billing failed:", error);
+  process.exit(1);
+});

--- a/scripts/reconcile-billing.mjs
+++ b/scripts/reconcile-billing.mjs
@@ -55,6 +55,17 @@ const userFilter = args.includes("--user")
   ? args[args.indexOf("--user") + 1]
   : null;
 
+// --user is interpolated into a PostgREST query (id=eq.<userFilter>); a
+// non-UUID value could inject filter syntax against the service-role client.
+if (userFilter !== null) {
+  const UUID_RE =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (!UUID_RE.test(userFilter)) {
+    console.error(`Invalid --user value (expected a UUID): ${userFilter}`);
+    process.exit(1);
+  }
+}
+
 const SUPABASE_URL = env.NEXT_PUBLIC_SUPABASE_URL;
 const SERVICE_ROLE_KEY = env.SUPABASE_SERVICE_ROLE_KEY;
 const STRIPE_KEY = env.STRIPE_SECRET_KEY;
@@ -128,7 +139,7 @@ function fmtState(state) {
   return `${state.plan}/${state.status} periodEnd=${state.currentPeriodEnd ?? "-"} cap=${state.cancelAtPeriodEnd}`;
 }
 
-async function applyCorrection(userId, providerState) {
+async function applyCorrection(userId, providerState, provider) {
   // PostgREST can't increment in place — read the version, write everything
   // in one PATCH (bumped version refreshes clients' claims).
   const rows = await supabaseRest(
@@ -142,6 +153,10 @@ async function applyCorrection(userId, providerState) {
       subscription_status: providerState.status,
       current_period_end: providerState.currentPeriodEnd,
       cancel_at_period_end: providerState.cancelAtPeriodEnd,
+      // Correct the provider too, else a drifted billing_provider is never
+      // fixed. A free/no-contract result on this provider carries NULL
+      // (matches the migration backfill: provider is set only for paid plans).
+      billing_provider: providerState.plan === "free" ? null : provider,
       billing_version: rows[0].billing_version + 1,
     }),
   });
@@ -276,7 +291,7 @@ async function main() {
 
     const verdict = decideApply(r.projection, r.providerState ?? null, r.diffs, r.side);
     if (APPLY && verdict.apply) {
-      await applyCorrection(r.userId, r.providerState);
+      await applyCorrection(r.userId, r.providerState, r.side);
       applied += 1;
       console.log(`    → APPLIED provider state`);
     } else if (verdict.apply) {

--- a/supabase/migrations/20260612080537_add_billing_provider.sql
+++ b/supabase/migrations/20260612080537_add_billing_provider.sql
@@ -1,0 +1,87 @@
+-- Cross-platform billing: record WHICH provider bills the user's current
+-- contract (decision ledger D-arch: the DB is the entitlement source of
+-- truth; Stripe and Apple each own the contracts they bill).
+--
+-- profile.billing_provider:
+--   'stripe' | 'apple' | NULL (no paid contract / never purchased)
+-- Written ONLY by webhook/service paths — the user-facing UPDATE policy
+-- pins it alongside the existing billing columns (same posture).
+
+ALTER TABLE "profile" ADD COLUMN IF NOT EXISTS "billing_provider" text;
+--> statement-breakpoint
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'profile_billing_provider_check'
+  ) THEN
+    ALTER TABLE "profile" ADD CONSTRAINT "profile_billing_provider_check"
+    CHECK (billing_provider IN ('stripe', 'apple'));
+  END IF;
+END $$;
+--> statement-breakpoint
+
+-- Backfill: every existing paid contract was billed by Stripe (the only
+-- provider that has ever existed for this app). Free/plan-less users carry
+-- NULL (no contract to attribute).
+UPDATE "profile"
+SET "billing_provider" = 'stripe'
+WHERE "plan_selected" IN ('premium', 'unlimited', 'lifetime')
+  AND "billing_provider" IS NULL;
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_profile_billing_provider"
+  ON "profile"("billing_provider");
+--> statement-breakpoint
+
+-- RLS: users must not self-modify billing_provider. Recreate the UPDATE
+-- policy with the new column added to the pinned set (same IS NOT DISTINCT
+-- FROM pattern as the existing billing columns).
+DROP POLICY IF EXISTS "Users can update their own profile" ON public.profile;
+--> statement-breakpoint
+
+CREATE POLICY "Users can update their own profile"
+ON public.profile
+FOR UPDATE
+TO authenticated
+USING (auth.uid()::uuid = id)
+WITH CHECK (
+  auth.uid()::uuid = id
+  AND email IS NOT DISTINCT FROM (SELECT email FROM profile WHERE id = auth.uid())
+  AND plan_selected IS NOT DISTINCT FROM (SELECT plan_selected FROM profile WHERE id = auth.uid())
+  AND subscription_status IS NOT DISTINCT FROM (SELECT subscription_status FROM profile WHERE id = auth.uid())
+  AND current_period_end IS NOT DISTINCT FROM (SELECT current_period_end FROM profile WHERE id = auth.uid())
+  AND cancel_at_period_end IS NOT DISTINCT FROM (SELECT cancel_at_period_end FROM profile WHERE id = auth.uid())
+  AND billing_version IS NOT DISTINCT FROM (SELECT billing_version FROM profile WHERE id = auth.uid())
+  AND billing_provider IS NOT DISTINCT FROM (SELECT billing_provider FROM profile WHERE id = auth.uid())
+);
+--> statement-breakpoint
+
+-- Per-provider out-of-order guard storage (handoff DoD #3): the RevenueCat
+-- webhook must ignore events older than the last APPLIED event from the
+-- same provider. webhook_events already provides idempotency; these two
+-- nullable columns let it also carry the provider cursor
+-- (max(event_time_ms) over success rows per user+provider). Existing
+-- Stripe rows stay NULL — Stripe handler semantics are unchanged.
+ALTER TABLE "webhook_events" ADD COLUMN IF NOT EXISTS "provider" text;
+--> statement-breakpoint
+
+ALTER TABLE "webhook_events" ADD COLUMN IF NOT EXISTS "event_time_ms" bigint;
+--> statement-breakpoint
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'webhook_events_provider_check'
+  ) THEN
+    ALTER TABLE "webhook_events" ADD CONSTRAINT "webhook_events_provider_check"
+    CHECK (provider IN ('stripe', 'apple'));
+  END IF;
+END $$;
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_webhook_events_provider_cursor"
+  ON "webhook_events"("user_id", "provider", "event_time_ms")
+  WHERE status = 'success';


### PR DESCRIPTION
Implements the cross-platform billing goal (docs/billing-implementation-handoff.md): Apple in-app purchases feed the SAME entitlement projection the existing Stripe billing feeds, with the locked §1 decision ledger implemented end-to-end and everything verified locally. The owner's remaining work is reduced to the console checklist in **docs/billing-runbook.md**.

## Definition of Done

| # | Item | Status | Evidence |
|---|---|---|---|
| 1 | Schema: `profile.billing_provider` via local migration; Drizzle + generated types in sync; RLS matches billing columns | ✅ | `20260612080537_add_billing_provider.sql` (CHECK + backfill + recreated no-self-modify policy + webhook_events cursor cols, D23); `check:schema-sync` green |
| 2 | Merge chokepoint `applyBillingEvent` (pure), exhaustively tested | ✅ | `apps/web/utils/billing/apply-billing-event.ts`; **78 unit tests** incl. programmatic precedence matrix, ordering guard, idempotence |
| 3 | RevenueCat webhook: auth, zod parse (official docs), idempotency, ordering, §2 mapping, billing_version++, double-contract alert w/o auto-cancel | ✅ | `app/api/webhooks/revenuecat/route.ts`; PRODUCT_CHANGE is write-free + cursor-free (D24) |
| 4 | Stripe handlers stamp provider + route writes through the same guards; suite stays green | ✅ | `guardedStripeProfileWrite` in every handler; lifetime + apple-active now protected; **644/644** |
| 5 | Integration tests vs real local Supabase: all event types + 401 + duplicate + stale + double-contract | ✅ | 26 RC-webhook + 10 stripe-guard integration tests |
| 6 | `scripts/reconcile-billing.mjs`, dry-run default, graceful RC-key skip, diff logic unit-tested | ✅ | 24 unit tests; dry-run clean on local stack (caught real period-end drift on an owner account) |
| 7 | Native provider seam: react-native-purchases + dev-client rebuild, factory keyed off `EXPO_PUBLIC_REVENUECAT_IOS_API_KEY`, mock without key, full Maestro suite passes key-less | ✅ | D25; **16/16 flows** on the rebuilt client, mock active |
| 8 | Policy-aware paywall (§1 matrix) on onboarding + profile; restore always; disclosure + legal links; real lineup (yearly only + lifetime) | ✅ | `paywallPolicyFor` (pure, tested); D26 |
| 9 | Per-state on-sim verification + captures + in-band judgment; test account restored | ✅ | 7 states driven (apple states via REAL webhook POSTs through the local pipeline); log table; account restored to unlimited/active/stripe + re-verified |
| 10 | Compliance: in-app account-deletion entry (5.1.1(v)) | ✅ | Web's REAL OTP deletion flow found; native Settings entry links to it (not an owner gap) |
| 11 | Owner runbook | ✅ | `docs/billing-runbook.md` — ASC, RevenueCat console, env vars, TestFlight plan, go-live order |
| 12 | Process: stacked branch, per-cluster commits, gates never bypassed, all green, log D22+ | ✅ | this PR; `docs/billing-implementation-log.md` (D22–D26, waivers: none) |

## Gate sweep
parity ✓ · check:tokens ✓ · schema-sync ✓ · web lint/tsc/**644 tests**/build ✓ · tokens 37 ✓ · native tsc/lint/**60 unit**/55 harness ✓ · expo export -p ios ✓ · prebuild ✓ · Maestro 16/16 + 7 state flows ✓

## Decisions (full rationale in the log)
- **D22** shared SKU module = `@handicappin/billing-core` workspace package
- **D23** per-provider ordering cursor rides `webhook_events` (provider + event_time_ms)
- **D24** PRODUCT_CHANGE writes nothing and never advances the cursor (RC dispatches the authoritative RENEWAL)
- **D25** lazy-required SDK + pure selection rule + real lineup in the mock
- **D26** non-active paid contracts show management affordances, never purchase buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added Apple in-app purchase support for iOS users with subscription management.
  * Added account deletion option in profile settings.
  * Enhanced billing interface to display subscription status, renewal dates, and payment issues.
  * Added "Restore Purchases" functionality for users.

* **Documentation**
  * Added operational runbook for billing setup and go-live procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->